### PR TITLE
chore: rename Chain to NamedChain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,5 +20,5 @@
 #[macro_use]
 extern crate alloc;
 
-mod chain;
-pub use chain::Chain;
+mod named;
+pub use named::NamedChain;


### PR DESCRIPTION
In preparation for porting `enum Chain { Named(NamedChain), Id(u64) }` from Reth/Foundry.