### PR TITLE
chore: add arbitrum one alias

### DIFF
--- a/src/named.rs
+++ b/src/named.rs
@@ -52,6 +52,7 @@ pub enum NamedChain {
     OptimismGoerli = 420,
     OptimismSepolia = 11155420,
 
+    #[cfg_attr(feature = "serde", serde(alias = "arbitrum_one"))]
     Arbitrum = 42161,
     ArbitrumTestnet = 421611,
     ArbitrumGoerli = 421613,


### PR DESCRIPTION
apparently this is an alias
https://www.alchemy.com/chain-connect/chain/arbitrum-one

ref https://github.com/foundry-rs/foundry/issues/6580