### PR TITLE
chore: unify etherscan url format

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -212,8 +212,8 @@
       "supportsShanghai": false,
       "isTestnet": true,
       "nativeCurrencySymbol": null,
-      "etherscanApiUrl": "https://zksync2-testnet-explorer.zksync.dev/",
-      "etherscanBaseUrl": "https://goerli.explorer.zksync.io/",
+      "etherscanApiUrl": "https://zksync2-testnet-explorer.zksync.dev",
+      "etherscanBaseUrl": "https://goerli.explorer.zksync.io",
       "etherscanApiKeyName": null
     },
     "288": {
@@ -248,8 +248,8 @@
       "supportsShanghai": false,
       "isTestnet": false,
       "nativeCurrencySymbol": null,
-      "etherscanApiUrl": "https://zksync2-mainnet-explorer.zksync.io/",
-      "etherscanBaseUrl": "https://explorer.zksync.io/",
+      "etherscanApiUrl": "https://zksync2-mainnet-explorer.zksync.io",
+      "etherscanBaseUrl": "https://explorer.zksync.io",
       "etherscanApiKeyName": null
     },
     "338": {
@@ -285,7 +285,7 @@
       "isTestnet": true,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://testnet-explorer.canto.neobase.one/api",
-      "etherscanBaseUrl": "https://testnet-explorer.canto.neobase.one/",
+      "etherscanBaseUrl": "https://testnet-explorer.canto.neobase.one",
       "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
     },
     "999": {
@@ -309,7 +309,7 @@
       "isTestnet": false,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://andromeda-explorer.metis.io/api",
-      "etherscanBaseUrl": "https://andromeda-explorer.metis.io/",
+      "etherscanBaseUrl": "https://andromeda-explorer.metis.io",
       "etherscanApiKeyName": null
     },
     "1101": {
@@ -345,7 +345,7 @@
       "isTestnet": false,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://api-moonbeam.moonscan.io/api",
-      "etherscanBaseUrl": "https://moonbeam.moonscan.io/",
+      "etherscanBaseUrl": "https://moonbeam.moonscan.io",
       "etherscanApiKeyName": "MOONSCAN_API_KEY"
     },
     "1285": {
@@ -369,7 +369,7 @@
       "isTestnet": false,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://api-moonbase.moonscan.io/api",
-      "etherscanBaseUrl": "https://moonbase.moonscan.io/",
+      "etherscanBaseUrl": "https://moonbase.moonscan.io",
       "etherscanApiKeyName": "MOONSCAN_API_KEY"
     },
     "1337": {
@@ -441,7 +441,7 @@
       "isTestnet": false,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://evm.explorer.canto.io/api",
-      "etherscanBaseUrl": "https://evm.explorer.canto.io/",
+      "etherscanBaseUrl": "https://evm.explorer.canto.io",
       "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
     },
     "8453": {
@@ -465,7 +465,7 @@
       "isTestnet": true,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://evm.evmos.dev/api",
-      "etherscanBaseUrl": "https://evm.evmos.dev/",
+      "etherscanBaseUrl": "https://evm.evmos.dev",
       "etherscanApiKeyName": null
     },
     "9001": {
@@ -477,7 +477,7 @@
       "isTestnet": false,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://evm.evmos.org/api",
-      "etherscanBaseUrl": "https://evm.evmos.org/",
+      "etherscanBaseUrl": "https://evm.evmos.org",
       "etherscanApiKeyName": null
     },
     "10200": {
@@ -513,7 +513,7 @@
       "isTestnet": false,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://scan.oasischain.io/api",
-      "etherscanBaseUrl": "https://scan.oasischain.io/",
+      "etherscanBaseUrl": "https://scan.oasischain.io",
       "etherscanApiKeyName": null
     },
     "31337": {
@@ -549,7 +549,7 @@
       "isTestnet": false,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://api-nova.arbiscan.io/api",
-      "etherscanBaseUrl": "https://nova.arbiscan.io/",
+      "etherscanBaseUrl": "https://nova.arbiscan.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "42220": {
@@ -573,7 +573,7 @@
       "isTestnet": true,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://testnet.explorer.emerald.oasis.dev/api",
-      "etherscanBaseUrl": "https://testnet.explorer.emerald.oasis.dev/",
+      "etherscanBaseUrl": "https://testnet.explorer.emerald.oasis.dev",
       "etherscanApiKeyName": null
     },
     "42262": {
@@ -585,7 +585,7 @@
       "isTestnet": false,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://explorer.emerald.oasis.dev/api",
-      "etherscanBaseUrl": "https://explorer.emerald.oasis.dev/",
+      "etherscanBaseUrl": "https://explorer.emerald.oasis.dev",
       "etherscanApiKeyName": null
     },
     "43113": {
@@ -633,7 +633,7 @@
       "isTestnet": true,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://explorer.goerli.linea.build/api",
-      "etherscanBaseUrl": "https://explorer.goerli.linea.build/",
+      "etherscanBaseUrl": "https://explorer.goerli.linea.build",
       "etherscanApiKeyName": null
     },
     "59144": {
@@ -645,7 +645,7 @@
       "isTestnet": false,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://api.lineascan.build/api",
-      "etherscanBaseUrl": "https://lineascan.build/",
+      "etherscanBaseUrl": "https://lineascan.build",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "62320": {
@@ -765,7 +765,7 @@
       "isTestnet": true,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://alpha-blockscout.scroll.io/api",
-      "etherscanBaseUrl": "https://alpha-blockscout.scroll.io/",
+      "etherscanBaseUrl": "https://alpha-blockscout.scroll.io",
       "etherscanApiKeyName": null
     },
     "7777777": {

--- a/src/named.rs
+++ b/src/named.rs
@@ -589,6 +589,8 @@ impl NamedChain {
     ///
     /// Returns `(API_URL, BASE_URL)`.
     ///
+    /// All URLs have no trailing `/`
+    ///
     /// # Examples
     ///
     /// ```
@@ -1005,5 +1007,15 @@ mod tests {
     fn test_dns_network() {
         let s = "enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE@all.mainnet.ethdisco.net";
         assert_eq!(NamedChain::Mainnet.public_dns_network_protocol().unwrap(), s);
+    }
+
+    #[test]
+    fn ensure_no_trailing_etherscan_url_separator() {
+        for chain in NamedChain::iter() {
+            if let Some((api, base)) = chain.etherscan_urls() {
+                assert!(!api.ends_with('/'), "{:?} api url has trailing /", chain);
+                assert!(!base.ends_with('/'), "{:?} base url has trailing /", chain);
+            }
+        }
     }
 }

--- a/src/named.rs
+++ b/src/named.rs
@@ -670,19 +670,15 @@ impl NamedChain {
             C::ArbitrumSepolia => {
                 ("https://api-sepolia.arbiscan.io/api", "https://sepolia.arbiscan.io")
             }
-            C::ArbitrumNova => ("https://api-nova.arbiscan.io/api", "https://nova.arbiscan.io/"),
+            C::ArbitrumNova => ("https://api-nova.arbiscan.io/api", "https://nova.arbiscan.io"),
 
             C::Cronos => ("https://api.cronoscan.com/api", "https://cronoscan.com"),
             C::CronosTestnet => {
                 ("https://api-testnet.cronoscan.com/api", "https://testnet.cronoscan.com")
             }
 
-            C::Moonbeam => {
-                ("https://api-moonbeam.moonscan.io/api", "https://moonbeam.moonscan.io/")
-            }
-            C::Moonbase => {
-                ("https://api-moonbase.moonscan.io/api", "https://moonbase.moonscan.io/")
-            }
+            C::Moonbeam => ("https://api-moonbeam.moonscan.io/api", "https://moonbeam.moonscan.io"),
+            C::Moonbase => ("https://api-moonbase.moonscan.io/api", "https://moonbase.moonscan.io"),
             C::Moonriver => {
                 ("https://api-moonriver.moonscan.io/api", "https://moonriver.moonscan.io")
             }
@@ -694,11 +690,11 @@ impl NamedChain {
                 ("https://api-sepolia.scrollscan.com/api", "https://sepolia.scrollscan.com")
             }
             C::ScrollAlphaTestnet => {
-                ("https://alpha-blockscout.scroll.io/api", "https://alpha-blockscout.scroll.io/")
+                ("https://alpha-blockscout.scroll.io/api", "https://alpha-blockscout.scroll.io")
             }
 
             C::Metis => {
-                ("https://andromeda-explorer.metis.io/api", "https://andromeda-explorer.metis.io/")
+                ("https://andromeda-explorer.metis.io/api", "https://andromeda-explorer.metis.io")
             }
 
             C::Chiado => {
@@ -720,14 +716,14 @@ impl NamedChain {
                 ("https://blockscout.com/rsk/mainnet/api", "https://blockscout.com/rsk/mainnet")
             }
 
-            C::Oasis => ("https://scan.oasischain.io/api", "https://scan.oasischain.io/"),
+            C::Oasis => ("https://scan.oasischain.io/api", "https://scan.oasischain.io"),
 
             C::Emerald => {
-                ("https://explorer.emerald.oasis.dev/api", "https://explorer.emerald.oasis.dev/")
+                ("https://explorer.emerald.oasis.dev/api", "https://explorer.emerald.oasis.dev")
             }
             C::EmeraldTestnet => (
                 "https://testnet.explorer.emerald.oasis.dev/api",
-                "https://testnet.explorer.emerald.oasis.dev/",
+                "https://testnet.explorer.emerald.oasis.dev",
             ),
 
             C::Aurora => ("https://api.aurorascan.dev/api", "https://aurorascan.dev"),
@@ -735,8 +731,8 @@ impl NamedChain {
                 ("https://testnet.aurorascan.dev/api", "https://testnet.aurorascan.dev")
             }
 
-            C::Evmos => ("https://evm.evmos.org/api", "https://evm.evmos.org/"),
-            C::EvmosTestnet => ("https://evm.evmos.dev/api", "https://evm.evmos.dev/"),
+            C::Evmos => ("https://evm.evmos.org/api", "https://evm.evmos.org"),
+            C::EvmosTestnet => ("https://evm.evmos.dev/api", "https://evm.evmos.dev"),
 
             C::Celo => {
                 ("https://explorer.celo.org/mainnet/api", "https://explorer.celo.org/mainnet")
@@ -748,10 +744,10 @@ impl NamedChain {
                 ("https://explorer.celo.org/baklava/api", "https://explorer.celo.org/baklava")
             }
 
-            C::Canto => ("https://evm.explorer.canto.io/api", "https://evm.explorer.canto.io/"),
+            C::Canto => ("https://evm.explorer.canto.io/api", "https://evm.explorer.canto.io"),
             C::CantoTestnet => (
                 "https://testnet-explorer.canto.neobase.one/api",
-                "https://testnet-explorer.canto.neobase.one/",
+                "https://testnet-explorer.canto.neobase.one",
             ),
 
             C::Boba => ("https://api.bobascan.com/api", "https://bobascan.com"),
@@ -760,16 +756,15 @@ impl NamedChain {
             C::BaseGoerli => ("https://api-goerli.basescan.org/api", "https://goerli.basescan.org"),
 
             C::ZkSync => {
-                ("https://zksync2-mainnet-explorer.zksync.io/", "https://explorer.zksync.io/")
+                ("https://zksync2-mainnet-explorer.zksync.io", "https://explorer.zksync.io")
             }
-            C::ZkSyncTestnet => (
-                "https://zksync2-testnet-explorer.zksync.dev/",
-                "https://goerli.explorer.zksync.io/",
-            ),
+            C::ZkSyncTestnet => {
+                ("https://zksync2-testnet-explorer.zksync.dev", "https://goerli.explorer.zksync.io")
+            }
 
-            C::Linea => ("https://api.lineascan.build/api", "https://lineascan.build/"),
+            C::Linea => ("https://api.lineascan.build/api", "https://lineascan.build"),
             C::LineaTestnet => {
-                ("https://explorer.goerli.linea.build/api", "https://explorer.goerli.linea.build/")
+                ("https://explorer.goerli.linea.build/api", "https://explorer.goerli.linea.build")
             }
 
             C::Mantle => ("https://explorer.mantle.xyz/api", "https://explorer.mantle.xyz"),


### PR DESCRIPTION
no trailing `/` on all etherscan urls