### PR TITLE
Add aliases for Base, BaseSepolia and BaseGoerli

### DIFF
--- a/src/named.rs
+++ b/src/named.rs
@@ -144,8 +144,14 @@ pub enum NamedChain {
 
     Boba = 288,
 
+    #[strum(to_string = "base")]
+    #[cfg_attr(feature="serde", serde(alias = "base"))]
     Base = 8453,
+    #[strum(to_string = "base-goerli")]
+    #[cfg_attr(feature="serde", serde(alias = "base_goerli"))]
     BaseGoerli = 84531,
+    #[strum(to_string = "base-sepolia")]
+    #[cfg_attr(feature="serde", serde(alias = "base_sepolia"))]
     BaseSepolia = 84532,
 
     BlastSepolia = 168587773,

--- a/src/named.rs
+++ b/src/named.rs
@@ -1052,6 +1052,9 @@ mod tests {
             (ZkSync, &["zksync"]),
             (Mantle, &["mantle"]),
             (MantleTestnet, &["mantle-testnet"]),
+            (Base, &["base"]),
+            (BaseGoerli, &["base-goerli"]),
+            (BaseSepolia, &["base-sepolia"]),
         ];
 
         for &(chain, aliases) in ALIASES {


### PR DESCRIPTION
## Motivation

There are no aliases set for Base Mainnet, Base Sepolia and Base Goerli.

## Solution

Add aliases for `Base`, `BaseGoerli` and `BaseSepolia` and related tests.