### PR TITLE
fix: correct blast api url

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -776,7 +776,7 @@
       "supportsShanghai": true,
       "isTestnet": false,
       "nativeCurrencySymbol": null,
-      "etherscanApiUrl": "https://api.routescan.io/v2/network/evm/81457/etherscan",
+      "etherscanApiUrl": "https://api.blastscan.io/api",
       "etherscanBaseUrl": "https://blastscan.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },

--- a/src/named.rs
+++ b/src/named.rs
@@ -892,7 +892,7 @@ impl NamedChain {
             }
 
             C::Blast => {
-                ("https://api.routescan.io/v2/network/evm/81457/etherscan", "https://blastscan.io")
+                ("https://api.blastscan.io/api", "https://blastscan.io")
             }
             C::BlastSepolia => (
                 "https://api.routescan.io/v2/network/testnet/evm/168587773/etherscan",

--- a/src/named.rs
+++ b/src/named.rs
@@ -891,9 +891,7 @@ impl NamedChain {
                 ("https://api-holesky.fraxscan.com/api", "https://holesky.fraxscan.com")
             }
 
-            C::Blast => {
-                ("https://api.blastscan.io/api", "https://blastscan.io")
-            }
+            C::Blast => ("https://api.blastscan.io/api", "https://blastscan.io"),
             C::BlastSepolia => (
                 "https://api.routescan.io/v2/network/testnet/evm/168587773/etherscan",
                 "https://testnet.blastscan.io",


### PR DESCRIPTION
Updating api_url related to [Blastscan API docs](https://blastscan.io/apis#accounts)

<img width="617" alt="image" src="https://github.com/alloy-rs/chains/assets/98172525/67147048-6843-4452-bcd5-e6f8b26a758e">