### PR TITLE
feat(chain): Add Etherlink Testnet

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -816,6 +816,18 @@
       "etherscanBaseUrl": "https://sepolia.basescan.org",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
+    "128123": {
+      "internalId": "EtherlinkTestnet",
+      "name": "etherlink-testnet",
+      "averageBlocktimeHint": 5000,
+      "isLegacy": false,
+      "supportsShanghai": true,
+      "isTestnet": true,
+      "nativeCurrencySymbol": "XTZ",
+      "etherscanApiUrl": "https://testnet-explorer.etherlink.com/api",
+      "etherscanBaseUrl": "https://testnet-explorer.etherlink.com",
+      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
+    },
     "314159": {
       "internalId": "FilecoinCalibrationTestnet",
       "name": "filecoin-calibration-testnet",

--- a/src/named.rs
+++ b/src/named.rs
@@ -227,6 +227,9 @@ pub enum NamedChain {
 
     #[cfg_attr(feature = "serde", serde(alias = "kakarot-sepolia"))]
     KakarotSepolia = 1802203764,
+
+    #[cfg_attr(feature = "serde", serde(alias = "etherlink-testnet"))]
+    EtherlinkTestnet = 128123,
 }
 
 // This must be implemented manually so we avoid a conflict with `TryFromPrimitive` where it treats
@@ -422,6 +425,8 @@ impl NamedChain {
 
             C::Elastos => 5_000,
 
+            C::EtherlinkTestnet => 5_000,
+
             C::Morden
             | C::Ropsten
             | C::Rinkeby
@@ -529,7 +534,8 @@ impl NamedChain {
             | C::ModeSepolia
             | C::Pgn
             | C::PgnSepolia
-            | C::KakarotSepolia => false,
+            | C::KakarotSepolia
+            | C::EtherlinkTestnet => false,
 
             // Unknown / not applicable, default to false for backwards compatibility.
             C::Dev
@@ -586,7 +592,8 @@ impl NamedChain {
             | C::Polygon
             | C::Arbitrum
             | C::ArbitrumNova
-            | C::ArbitrumSepolia => true,
+            | C::ArbitrumSepolia
+            | C::EtherlinkTestnet => true,
             _ => false,
         }
     }
@@ -647,7 +654,8 @@ impl NamedChain {
             | C::ZoraSepolia
             | C::ModeSepolia
             | C::PgnSepolia
-            | C::KakarotSepolia => true,
+            | C::KakarotSepolia
+            | C::EtherlinkTestnet => true,
 
             // Dev chains.
             C::Dev | C::AnvilHardhat => true,
@@ -710,6 +718,8 @@ impl NamedChain {
             | C::Rinkeby => "ETH",
 
             C::BinanceSmartChain | C::BinanceSmartChainTestnet => "BNB",
+
+            C::EtherlinkTestnet => "XTZ",
 
             _ => return None,
         })
@@ -956,6 +966,10 @@ impl NamedChain {
             C::KakarotSepolia => {
                 ("https://sepolia.kakarotscan.org/api", "https://sepolia.kakarotscan.org")
             }
+            C::EtherlinkTestnet => (
+                "https://testnet-explorer.etherlink.com/api",
+                "https://testnet-explorer.etherlink.com",
+            ),
         })
     }
 
@@ -1034,7 +1048,8 @@ impl NamedChain {
             | C::ModeSepolia
             | C::Pgn
             | C::PgnSepolia
-            | C::KakarotSepolia => "BLOCKSCOUT_API_KEY",
+            | C::KakarotSepolia
+            | C::EtherlinkTestnet => "BLOCKSCOUT_API_KEY",
 
             C::Boba => "BOBASCAN_API_KEY",
 


### PR DESCRIPTION
:wave: this PR is here to add the support for Etherlink Testnet. Etherlink is a layer 2 blockchain EVM compatible with a well-established testnet already.

I’m not totally sure about the contributing guidelines to add new network, so I hope this PR does not come outside of a due process. If it is the case, please don’t hesitate to redirect me in the right direction!