### PR TITLE
fix: correct Etherscan URLs for Blast Sepolia

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -968,8 +968,8 @@
       "supportsShanghai": true,
       "isTestnet": true,
       "nativeCurrencySymbol": null,
-      "etherscanApiUrl": "https://api.routescan.io/v2/network/testnet/evm/168587773/etherscan",
-      "etherscanBaseUrl": "https://testnet.blastscan.io",
+      "etherscanApiUrl": "https://api-sepolia.blastscan.io/api",
+      "etherscanBaseUrl": "https://sepolia.blastscan.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "666666666": {

--- a/src/named.rs
+++ b/src/named.rs
@@ -931,8 +931,8 @@ impl NamedChain {
 
             C::Blast => ("https://api.blastscan.io/api", "https://blastscan.io"),
             C::BlastSepolia => (
-                "https://api.routescan.io/v2/network/testnet/evm/168587773/etherscan",
-                "https://testnet.blastscan.io",
+                "https://api-sepolia.blastscan.io/api",
+                "https://sepolia.blastscan.io",
             ),
 
             C::ZkSync => {

--- a/src/named.rs
+++ b/src/named.rs
@@ -930,10 +930,9 @@ impl NamedChain {
             }
 
             C::Blast => ("https://api.blastscan.io/api", "https://blastscan.io"),
-            C::BlastSepolia => (
-                "https://api-sepolia.blastscan.io/api",
-                "https://sepolia.blastscan.io",
-            ),
+            C::BlastSepolia => {
+                ("https://api-sepolia.blastscan.io/api", "https://sepolia.blastscan.io")
+            }
 
             C::ZkSync => {
                 ("https://zksync2-mainnet-explorer.zksync.io", "https://explorer.zksync.io")


### PR DESCRIPTION
Currently this repo uses the Routescan URL's for verification with Blast Sepolia making it unable to verify contracts through Blastscan.

This PR updates them to properly use Etherscan (Blastscan) instead just as Blast mainnet does.