### PR TITLE
fix: correct Arbiturm blocktime hint

### DIFF
--- a/src/named.rs
+++ b/src/named.rs
@@ -377,7 +377,7 @@ impl NamedChain {
             | C::ArbitrumSepolia
             | C::Syndr
             | C::SyndrSepolia
-            | C::ArbitrumNova => 1_300,
+            | C::ArbitrumNova => 260,
 
             C::Optimism
             | C::OptimismGoerli


### PR DESCRIPTION
Recent average block time of Arbitrum is around 0.26s. Data is from https://arbiscan.io/chart/blocktime (download csv)