### PR TITLE
fix: update Amoy testnet endpoints

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -788,8 +788,8 @@
       "supportsShanghai": false,
       "isTestnet": true,
       "nativeCurrencySymbol": null,
-      "etherscanApiUrl": "https://www.oklink.com/api/v5/explorer/AMOY_TESTNET/api",
-      "etherscanBaseUrl": "https://www.oklink.com/amoy",
+      "etherscanApiUrl": "https://api-amoy.polygonscan.com/api",
+      "etherscanBaseUrl": "https://amoy.polygonscan.com",
       "etherscanApiKeyName": "POLYGONSCAN_API_KEY"
     },
     "81457": {

--- a/src/named.rs
+++ b/src/named.rs
@@ -780,10 +780,9 @@ impl NamedChain {
             C::PolygonMumbai => {
                 ("https://api-testnet.polygonscan.com/api", "https://mumbai.polygonscan.com")
             }
-            C::PolygonAmoy => (
-                "https://api-amoy.polygonscan.com/api",
-                "https://amoy.polygonscan.com",
-            ),
+            C::PolygonAmoy => {
+                ("https://api-amoy.polygonscan.com/api", "https://amoy.polygonscan.com")
+            }
 
             C::PolygonZkEvm => {
                 ("https://api-zkevm.polygonscan.com/api", "https://zkevm.polygonscan.com")

--- a/src/named.rs
+++ b/src/named.rs
@@ -781,8 +781,8 @@ impl NamedChain {
                 ("https://api-testnet.polygonscan.com/api", "https://mumbai.polygonscan.com")
             }
             C::PolygonAmoy => (
-                "https://www.oklink.com/api/v5/explorer/AMOY_TESTNET/api",
-                "https://www.oklink.com/amoy",
+                "https://api-amoy.polygonscan.com/api",
+                "https://amoy.polygonscan.com",
             ),
 
             C::PolygonZkEvm => {


### PR DESCRIPTION
Use `amoy.polygonscan.com` as both explorer and verification endpoint

ref https://github.com/foundry-rs/foundry/issues/7922
ref https://github.com/foundry-rs/foundry/issues/7724