### PR TITLE
feat(chain): add opBNB mainnet and testnet

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -216,6 +216,18 @@
       "etherscanBaseUrl": "https://polygonscan.com",
       "etherscanApiKeyName": "POLYGONSCAN_API_KEY"
     },
+    "204": {
+      "internalId": "OpBNBMainnet",
+      "name": "op-bnb-mainnet",
+      "averageBlocktimeHint": 1000,
+      "isLegacy": false,
+      "supportsShanghai": true,
+      "isTestnet": false,
+      "nativeCurrencySymbol": "BNB",
+      "etherscanApiUrl": "https://opbnb.bscscan.com/api",
+      "etherscanBaseUrl": "https://opbnb.bscscan.com/",
+      "etherscanApiKeyName": "ETHERSCAN_API_KEY"
+    },
     "250": {
       "internalId": "Fantom",
       "name": "fantom",
@@ -514,6 +526,18 @@
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://explorer.testnet.mantle.xyz/api",
       "etherscanBaseUrl": "https://explorer.testnet.mantle.xyz",
+      "etherscanApiKeyName": "ETHERSCAN_API_KEY"
+    },
+    "5611": {
+      "internalId": "OpBNBTestnet",
+      "name": "op-bnb-testnet",
+      "averageBlocktimeHint": 1000,
+      "isLegacy": false,
+      "supportsShanghai": true,
+      "isTestnet": true,
+      "nativeCurrencySymbol": "BNB",
+      "etherscanApiUrl": "https://opbnb-testnet.bscscan.com/api",
+      "etherscanBaseUrl": "https://opbnb-testnet.bscscan.com/",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "7700": {

--- a/assets/chains.json
+++ b/assets/chains.json
@@ -218,14 +218,14 @@
     },
     "204": {
       "internalId": "OpBNBMainnet",
-      "name": "op-bnb-mainnet",
+      "name": "opbnb-mainnet",
       "averageBlocktimeHint": 1000,
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": false,
       "nativeCurrencySymbol": "BNB",
       "etherscanApiUrl": "https://opbnb.bscscan.com/api",
-      "etherscanBaseUrl": "https://opbnb.bscscan.com/",
+      "etherscanBaseUrl": "https://opbnb.bscscan.com",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "250": {
@@ -530,14 +530,14 @@
     },
     "5611": {
       "internalId": "OpBNBTestnet",
-      "name": "op-bnb-testnet",
+      "name": "opbnb-testnet",
       "averageBlocktimeHint": 1000,
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": true,
       "nativeCurrencySymbol": "BNB",
       "etherscanApiUrl": "https://opbnb-testnet.bscscan.com/api",
-      "etherscanBaseUrl": "https://opbnb-testnet.bscscan.com/",
+      "etherscanBaseUrl": "https://opbnb-testnet.bscscan.com",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "7700": {

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -384,6 +384,18 @@ impl Chain {
         Self::from_named(NamedChain::Dev)
     }
 
+    /// Returns the opbnb mainnet chain.
+    #[inline]
+    pub const fn opbnb_mainnet() -> Self {
+        Self::from_named(NamedChain::OpBNBMainnet)
+    }
+
+    /// Returns the opbnb testnet chain.
+    #[inline]
+    pub const fn opbnb_testnet() -> Self {
+        Self::from_named(NamedChain::OpBNBTestnet)
+    }
+
     /// Returns the kind of this chain.
     #[inline]
     pub const fn kind(&self) -> &ChainKind {
@@ -419,6 +431,8 @@ impl Chain {
                     | NamedChain::ZoraGoerli
                     | NamedChain::ZoraSepolia
                     | NamedChain::BlastSepolia
+                    | NamedChain::OpBNBMainnet
+                    | NamedChain::OpBNBTestnet
             )
         )
     }

--- a/src/named.rs
+++ b/src/named.rs
@@ -466,8 +466,7 @@ impl NamedChain {
             | C::MantleTestnet
             | C::KakarotSepolia => return None,
 
-            C::OpBNBMainnet
-            | C::OpBNBTestnet => 1_000,
+            C::OpBNBMainnet | C::OpBNBTestnet => 1_000,
         }))
     }
 

--- a/src/named.rs
+++ b/src/named.rs
@@ -235,6 +235,11 @@ pub enum NamedChain {
     EtherlinkTestnet = 128123,
 
     Degen = 666666666,
+
+    #[cfg_attr(feature = "serde", serde(alias = "opbnb-mainnet"))]
+    OpBNBMainnet = 204,
+    #[cfg_attr(feature = "serde", serde(alias = "opbnb-testnet"))]
+    OpBNBTestnet = 5611,
 }
 
 // This must be implemented manually so we avoid a conflict with `TryFromPrimitive` where it treats
@@ -460,6 +465,9 @@ impl NamedChain {
             | C::Mantle
             | C::MantleTestnet
             | C::KakarotSepolia => return None,
+
+            C::OpBNBMainnet
+            | C::OpBNBTestnet => 1_000,
         }))
     }
 
@@ -545,7 +553,9 @@ impl NamedChain {
             | C::PgnSepolia
             | C::KakarotSepolia
             | C::EtherlinkTestnet
-            | C::Degen => false,
+            | C::Degen
+            | C::OpBNBMainnet
+            | C::OpBNBTestnet => false,
 
             // Unknown / not applicable, default to false for backwards compatibility.
             C::Dev
@@ -606,7 +616,9 @@ impl NamedChain {
             | C::SyndrSepolia
             | C::EtherlinkTestnet
             | C::Scroll
-            | C::ScrollSepolia => true,
+            | C::ScrollSepolia
+            | C::OpBNBMainnet
+            | C::OpBNBTestnet => true,
             _ => false,
         }
     }
@@ -667,7 +679,8 @@ impl NamedChain {
             | C::ModeSepolia
             | C::PgnSepolia
             | C::KakarotSepolia
-            | C::EtherlinkTestnet => true,
+            | C::EtherlinkTestnet
+            | C::OpBNBTestnet => true,
 
             // Dev chains.
             C::Dev | C::AnvilHardhat => true,
@@ -713,7 +726,8 @@ impl NamedChain {
             | C::Mode
             | C::Viction
             | C::Elastos
-            | C::Degen => false,
+            | C::Degen
+            | C::OpBNBMainnet => false,
         }
     }
 
@@ -733,7 +747,10 @@ impl NamedChain {
             | C::Scroll
             | C::ScrollSepolia => "ETH",
 
-            C::BinanceSmartChain | C::BinanceSmartChainTestnet => "BNB",
+            C::BinanceSmartChain
+            | C::BinanceSmartChainTestnet
+            | C::OpBNBMainnet
+            | C::OpBNBTestnet => "BNB",
 
             C::EtherlinkTestnet => "XTZ",
 
@@ -821,6 +838,11 @@ impl NamedChain {
             C::BinanceSmartChain => ("https://api.bscscan.com/api", "https://bscscan.com"),
             C::BinanceSmartChainTestnet => {
                 ("https://api-testnet.bscscan.com/api", "https://testnet.bscscan.com")
+            }
+
+            C::OpBNBMainnet => ("https://opbnb.bscscan.com/api", "https://opbnb.bscscan.com/"),
+            C::OpBNBTestnet => {
+                ("https://opbnb-testnet.bscscan.com/api", "https://opbnb-testnet.bscscan.com/")
             }
 
             C::Arbitrum => ("https://api.arbiscan.io/api", "https://arbiscan.io"),
@@ -1018,6 +1040,8 @@ impl NamedChain {
             | C::OptimismSepolia
             | C::BinanceSmartChain
             | C::BinanceSmartChainTestnet
+            | C::OpBNBMainnet
+            | C::OpBNBTestnet
             | C::Arbitrum
             | C::ArbitrumTestnet
             | C::ArbitrumGoerli

--- a/src/named.rs
+++ b/src/named.rs
@@ -236,9 +236,17 @@ pub enum NamedChain {
 
     Degen = 666666666,
 
-    #[cfg_attr(feature = "serde", serde(alias = "opbnb-mainnet"))]
+    #[strum(to_string = "opbnb-mainnet")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "opbnb_mainnet", alias = "opbnb-mainnet", alias = "op-bnb-mainnet")
+    )]
     OpBNBMainnet = 204,
-    #[cfg_attr(feature = "serde", serde(alias = "opbnb-testnet"))]
+    #[strum(to_string = "opbnb-testnet")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "opbnb_testnet", alias = "opbnb-testnet", alias = "op-bnb-testnet")
+    )]
     OpBNBTestnet = 5611,
 }
 
@@ -839,9 +847,9 @@ impl NamedChain {
                 ("https://api-testnet.bscscan.com/api", "https://testnet.bscscan.com")
             }
 
-            C::OpBNBMainnet => ("https://opbnb.bscscan.com/api", "https://opbnb.bscscan.com/"),
+            C::OpBNBMainnet => ("https://opbnb.bscscan.com/api", "https://opbnb.bscscan.com"),
             C::OpBNBTestnet => {
-                ("https://opbnb-testnet.bscscan.com/api", "https://opbnb-testnet.bscscan.com/")
+                ("https://opbnb-testnet.bscscan.com/api", "https://opbnb-testnet.bscscan.com")
             }
 
             C::Arbitrum => ("https://api.arbiscan.io/api", "https://arbiscan.io"),


### PR DESCRIPTION
👋 this PR is here to add the support for opBNB Mainnet/Testnet. opBNB is a layer 2 blockchain EVM compatible with a well-established already.

We are currently developing reth to support opBNB, so hope Chain Sepc can be added to the official repository.