### PR TITLE
Shimmer + Flare support

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -72,6 +72,18 @@
       "etherscanBaseUrl": "https://optimistic.etherscan.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
+    "14": {
+      "internalId": "Flare",
+      "name": "flare",
+      "averageBlocktimeHint": 1800,
+      "isLegacy": false,
+      "supportsShanghai": false,
+      "isTestnet": false,
+      "nativeCurrencySymbol": "FLR",
+      "etherscanApiUrl": "https://flare-explorer.flare.network/api",
+      "etherscanBaseUrl": "https://flare-explorer.flare.network",
+      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
+    },
     "20": {
       "internalId": "Elastos",
       "name": "elastos",
@@ -204,6 +216,18 @@
       "etherscanBaseUrl": "https://gnosisscan.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
+    "114": {
+      "internalId": "FlareCoston2",
+      "name": "flare-coston2",
+      "averageBlocktimeHint": 2500,
+      "isLegacy": false,
+      "supportsShanghai": false,
+      "isTestnet": true,
+      "nativeCurrencySymbol": "C2FLR",
+      "etherscanApiUrl": "https://coston2-explorer.flare.network/api",
+      "etherscanBaseUrl": "https://coston2-explorer.flare.network",
+      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
+    },
     "137": {
       "internalId": "Polygon",
       "name": "polygon",
@@ -226,7 +250,7 @@
       "nativeCurrencySymbol": "SMR",
       "etherscanApiUrl": "https://explorer.evm.shimmer.network/api",
       "etherscanBaseUrl": "https://explorer.evm.shimmer.network",
-      "etherscanApiKeyName": null
+      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
     },
     "204": {
       "internalId": "OpBNBMainnet",

--- a/assets/chains.json
+++ b/assets/chains.json
@@ -223,7 +223,7 @@
       "isLegacy": true,
       "supportsShanghai": true,
       "isTestnet": true,
-      "nativeCurrencySymbol": null,
+      "nativeCurrencySymbol": "SMR",
       "etherscanApiUrl": "https://explorer.evm.shimmer.network/api",
       "etherscanBaseUrl": "https://explorer.evm.shimmer.network",
       "etherscanApiKeyName": null

--- a/assets/chains.json
+++ b/assets/chains.json
@@ -225,7 +225,7 @@
       "isTestnet": true,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://explorer.evm.shimmer.network/api",
-      "etherscanBaseUrl": "https://explorer.evm.shimmer.network/",
+      "etherscanBaseUrl": "https://explorer.evm.shimmer.network",
       "etherscanApiKeyName": null
     },
     "204": {

--- a/assets/chains.json
+++ b/assets/chains.json
@@ -216,6 +216,18 @@
       "etherscanBaseUrl": "https://polygonscan.com",
       "etherscanApiKeyName": "POLYGONSCAN_API_KEY"
     },
+    "148": {
+      "internalId": "Shimmer",
+      "name": "shimmer",
+      "averageBlocktimeHint": 5000,
+      "isLegacy": true,
+      "supportsShanghai": true,
+      "isTestnet": true,
+      "nativeCurrencySymbol": null,
+      "etherscanApiUrl": "https://explorer.evm.shimmer.network/api",
+      "etherscanBaseUrl": "https://explorer.evm.shimmer.network/",
+      "etherscanApiKeyName": null
+    },
     "204": {
       "internalId": "OpBNBMainnet",
       "name": "opbnb-mainnet",

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -420,6 +420,17 @@ impl Chain {
         Self::from_named(NamedChain::Shimmer)
     }
 
+    /// Returns the flare mainnet chain.
+    #[inline]
+    pub const fn flare() -> Self {
+        Self::from_named(NamedChain::Flare)
+    }
+
+    /// Returns the flare testnet chain.
+    #[inline]
+    pub const fn flare_coston2() -> Self {
+        Self::from_named(NamedChain::FlareCoston2)
+    }
     /// Returns the kind of this chain.
     #[inline]
     pub const fn kind(&self) -> &ChainKind {

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -414,6 +414,12 @@ impl Chain {
         Self::from_named(NamedChain::TaikoHekla)
     }
 
+    /// Returns the shimmer testnet chain.
+    #[inline]
+    pub const fn shimmer() -> Self {
+        Self::from_named(NamedChain::Shimmer)
+    }
+
     /// Returns the kind of this chain.
     #[inline]
     pub const fn kind(&self) -> &ChainKind {

--- a/src/named.rs
+++ b/src/named.rs
@@ -648,6 +648,7 @@ impl NamedChain {
             | C::EtherlinkTestnet
             | C::Scroll
             | C::ScrollSepolia
+            | C::Shimmer
             | C::OpBNBMainnet
             | C::OpBNBTestnet
             | C::KakarotSepolia

--- a/src/named.rs
+++ b/src/named.rs
@@ -926,9 +926,10 @@ impl NamedChain {
                 ("https://api-sepolia.scrollscan.com/api", "https://sepolia.scrollscan.com")
             }
 
-            C::Shimmer => {
-                ("https://explorer.evm.shimmer.network/api", "https://explorer.evm.shimmer.network/")
-            }
+            C::Shimmer => (
+                "https://explorer.evm.shimmer.network/api",
+                "https://explorer.evm.shimmer.network",
+            ),
 
             C::Metis => {
                 ("https://andromeda-explorer.metis.io/api", "https://andromeda-explorer.metis.io")

--- a/src/named.rs
+++ b/src/named.rs
@@ -181,6 +181,8 @@ pub enum NamedChain {
     #[cfg_attr(feature = "serde", serde(alias = "syndr-sepolia"))]
     SyndrSepolia = 444444,
 
+    Shimmer = 148,
+
     #[strum(to_string = "fraxtal")]
     #[cfg_attr(feature = "serde", serde(alias = "fraxtal"))]
     Fraxtal = 252,
@@ -453,6 +455,8 @@ impl NamedChain {
 
             C::Scroll | C::ScrollSepolia => 3_000,
 
+            C::Shimmer => 5_000,
+
             C::Gnosis | C::Chiado => 5_000,
 
             C::Elastos => 5_000,
@@ -530,6 +534,7 @@ impl NamedChain {
             | C::PolygonZkEvmTestnet
             | C::Scroll
             | C::ScrollSepolia
+            | C::Shimmer
             | C::Metis
             | C::Viction
             | C::Elastos
@@ -703,6 +708,7 @@ impl NamedChain {
             | C::PolygonAmoy
             | C::PolygonZkEvmTestnet
             | C::ScrollSepolia
+            | C::Shimmer
             | C::ZkSyncTestnet
             | C::ZoraGoerli
             | C::ZoraSepolia
@@ -793,6 +799,8 @@ impl NamedChain {
             C::Degen => "DEGEN",
 
             C::Ronin => "RON",
+
+            C::Shimmer => "SMR",
 
             _ => return None,
         })
@@ -916,6 +924,10 @@ impl NamedChain {
             C::Scroll => ("https://api.scrollscan.com/api", "https://scrollscan.com"),
             C::ScrollSepolia => {
                 ("https://api-sepolia.scrollscan.com/api", "https://sepolia.scrollscan.com")
+            }
+
+            C::Shimmer => {
+                ("https://explorer.evm.shimmer.network/api", "https://explorer.evm.shimmer.network/")
             }
 
             C::Metis => {
@@ -1148,6 +1160,7 @@ impl NamedChain {
             C::Metis
             | C::Chiado
             | C::Sepolia
+            | C::Shimmer
             | C::Rsk
             | C::Sokol
             | C::Poa

--- a/src/named.rs
+++ b/src/named.rs
@@ -263,6 +263,10 @@ pub enum NamedChain {
         serde(rename = "autonomys_nova_testnet", alias = "autonomys-nova-testnet")
     )]
     AutonomysNovaTestnet = 490000,
+
+    Flare = 14,
+    #[cfg_attr(feature = "serde", serde(alias = "flare-coston2"))]
+    FlareCoston2 = 114,
 }
 
 // This must be implemented manually so we avoid a conflict with `TryFromPrimitive` where it treats
@@ -494,6 +498,10 @@ impl NamedChain {
             C::OpBNBMainnet | C::OpBNBTestnet | C::AutonomysNovaTestnet => 1_000,
 
             C::Ronin => 3_000,
+
+            C::Flare => 1_800,
+
+            C::FlareCoston2 => 2_500,
         }))
     }
 
@@ -586,7 +594,9 @@ impl NamedChain {
             | C::OpBNBTestnet
             | C::Taiko
             | C::TaikoHekla
-            | C::AutonomysNovaTestnet => false,
+            | C::AutonomysNovaTestnet
+            | C::Flare
+            | C::FlareCoston2 => false,
 
             // Unknown / not applicable, default to false for backwards compatibility.
             C::Dev
@@ -719,7 +729,8 @@ impl NamedChain {
             | C::EtherlinkTestnet
             | C::OpBNBTestnet
             | C::TaikoHekla
-            | C::AutonomysNovaTestnet => true,
+            | C::AutonomysNovaTestnet
+            | C::FlareCoston2 => true,
 
             // Dev chains.
             C::Dev | C::AnvilHardhat => true,
@@ -768,7 +779,8 @@ impl NamedChain {
             | C::Degen
             | C::OpBNBMainnet
             | C::Ronin
-            | C::Taiko => false,
+            | C::Taiko
+            | C::Flare => false,
         }
     }
 
@@ -802,6 +814,10 @@ impl NamedChain {
             C::Ronin => "RON",
 
             C::Shimmer => "SMR",
+
+            C::Flare => "FLR",
+
+            C::FlareCoston2 => "C2FLR",
 
             _ => return None,
         })
@@ -927,10 +943,9 @@ impl NamedChain {
                 ("https://api-sepolia.scrollscan.com/api", "https://sepolia.scrollscan.com")
             }
 
-            C::Shimmer => (
-                "https://explorer.evm.shimmer.network/api",
-                "https://explorer.evm.shimmer.network",
-            ),
+            C::Shimmer => {
+                ("https://explorer.evm.shimmer.network/api", "https://explorer.evm.shimmer.network")
+            }
 
             C::Metis => {
                 ("https://andromeda-explorer.metis.io/api", "https://andromeda-explorer.metis.io")
@@ -1070,6 +1085,13 @@ impl NamedChain {
             C::Ronin => ("https://skynet-api.roninchain.com/ronin", "https://app.roninchain.com"),
             C::Taiko => ("https://api.taikoscan.io/api", "https://taikoscan.io"),
             C::TaikoHekla => ("https://api-testnet.taikoscan.io/api", "https://hekla.taikoscan.io"),
+            C::Flare => {
+                ("https://flare-explorer.flare.network/api", "https://flare-explorer.flare.network")
+            }
+            C::FlareCoston2 => (
+                "https://coston2-explorer.flare.network/api",
+                "https://coston2-explorer.flare.network",
+            ),
         })
     }
 
@@ -1154,7 +1176,10 @@ impl NamedChain {
             | C::Pgn
             | C::PgnSepolia
             | C::KakarotSepolia
-            | C::EtherlinkTestnet => "BLOCKSCOUT_API_KEY",
+            | C::EtherlinkTestnet
+            | C::Shimmer
+            | C::Flare
+            | C::FlareCoston2 => "BLOCKSCOUT_API_KEY",
 
             C::Boba => "BOBASCAN_API_KEY",
 
@@ -1162,7 +1187,6 @@ impl NamedChain {
             C::Metis
             | C::Chiado
             | C::Sepolia
-            | C::Shimmer
             | C::Rsk
             | C::Sokol
             | C::Poa


### PR DESCRIPTION
Adds support for shimmer network https://shimmer.network/ and flare networks https://docs.flare.network/

Shimmer marked as a legacy because of this issue: https://github.com/iotaledger/wasp/issues/3392
Flare derives codebase from avalanche so it does not support shanghai fork, but they ported EIP-1559 support