### PR TITLE
Fix: `anvil` reports not supporting `EIP-3855` (Shanghai)

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -785,7 +785,7 @@
       "name": "anvil-hardhat",
       "averageBlocktimeHint": 200,
       "isLegacy": false,
-      "supportsShanghai": false,
+      "supportsShanghai": true,
       "isTestnet": true,
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": null,

--- a/src/named.rs
+++ b/src/named.rs
@@ -690,6 +690,7 @@ impl NamedChain {
             | C::Goerli
             | C::Sepolia
             | C::Holesky
+            | C::AnvilHardhat
             | C::Optimism
             | C::OptimismGoerli
             | C::OptimismSepolia


### PR DESCRIPTION
Mark `AnvilHardhat` as shanghai compatible as it is launched with `latest` by default (`cancun`)

Closes https://github.com/foundry-rs/foundry/issues/8730

Related code in Foundry: https://github.com/foundry-rs/foundry/blob/44cceb4a3d0a64faf818f16ce7c6ab7dc3a27400/crates/script/src/execute.rs#L234-L259