### PR TITLE
add: Immutable zkEVM and Immutable zkEVM testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Features
+
+- Add immutable mainnet and testnet ([#88](https://github.com/alloy-rs/chains/issues/88))
+
 ## [0.1.30](https://github.com/alloy-rs/chains/releases/tag/v0.1.30) - 2024-09-06
 
 ### Features

--- a/assets/chains.json
+++ b/assets/chains.json
@@ -816,6 +816,30 @@
       "etherscanBaseUrl": "https://blockscout.chiadochain.net",
       "etherscanApiKeyName": null
     },
+    "13371": {
+      "internalId": "Immutable",
+      "name": "immutable",
+      "averageBlocktimeHint": 2000,
+      "isLegacy": false,
+      "supportsShanghai": true,
+      "isTestnet": false,
+      "nativeCurrencySymbol": "IMX",
+      "etherscanApiUrl": "https://explorer.immutable.com/api",
+      "etherscanBaseUrl": "https://explorer.immutable.com",
+      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
+    },
+    "13473": {
+      "internalId": "ImmutableTestnet",
+      "name": "immutable-testnet",
+      "averageBlocktimeHint": 2000,
+      "isLegacy": false,
+      "supportsShanghai": true,
+      "isTestnet": true,
+      "nativeCurrencySymbol": "tIMX",
+      "etherscanApiUrl": "https://explorer.testnet.immutable.com/api",
+      "etherscanBaseUrl": "https://explorer.testnet.immutable.com",
+      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
+    },
     "13505": {
       "internalId": "GravityAlphaTestnetSepolia",
       "name": "gravity-alpha-testnet-sepolia",

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -450,6 +450,18 @@ impl Chain {
         Self::from_named(NamedChain::Koi)
     }
 
+    /// Returns the Immutable zkEVM mainnet chain.
+    #[inline]
+        pub const fn immutable() -> Self {
+            Self::from_named(NamedChain::Immutable)
+    }
+    
+    /// Returns the Immutable zkEVM testnet chain.
+    #[inline]
+        pub const fn immutable_testnet() -> Self {
+            Self::from_named(NamedChain::ImmutableTestnet)
+    }
+
     /// Returns the kind of this chain.
     #[inline]
     pub const fn kind(&self) -> &ChainKind {

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -452,14 +452,14 @@ impl Chain {
 
     /// Returns the Immutable zkEVM mainnet chain.
     #[inline]
-        pub const fn immutable() -> Self {
-            Self::from_named(NamedChain::Immutable)
+    pub const fn immutable() -> Self {
+        Self::from_named(NamedChain::Immutable)
     }
-    
+
     /// Returns the Immutable zkEVM testnet chain.
     #[inline]
-        pub const fn immutable_testnet() -> Self {
-            Self::from_named(NamedChain::ImmutableTestnet)
+    pub const fn immutable_testnet() -> Self {
+        Self::from_named(NamedChain::ImmutableTestnet)
     }
 
     /// Returns the kind of this chain.

--- a/src/named.rs
+++ b/src/named.rs
@@ -335,7 +335,6 @@ pub enum NamedChain {
     #[strum(to_string = "immutable-testnet")]
     #[cfg_attr(feature = "serde", serde(alias = "immutable-testnet"))]
     ImmutableTestnet = 13473,
-
 }
 
 // This must be implemented manually so we avoid a conflict with `TryFromPrimitive` where it treats
@@ -1320,7 +1319,9 @@ impl NamedChain {
                 "https://scan.v4.testnet.pulsechain.com",
             ),
 
-            C::Immutable => ("https://explorer.immutable.com/api", "https://explorer.immutable.com"),
+            C::Immutable => {
+                ("https://explorer.immutable.com/api", "https://explorer.immutable.com")
+            }
             C::ImmutableTestnet => (
                 "https://explorer.testnet.immutable.com/api",
                 "https://explorer.testnet.immutable.com",

--- a/src/named.rs
+++ b/src/named.rs
@@ -1584,6 +1584,7 @@ mod tests {
             (SyndrSepolia, &["syndr-sepolia"]),
             (LineaGoerli, &["linea-goerli"]),
             (AutonomysNovaTestnet, &["autonomys-nova-testnet"]),
+            (Immutable, &["immutable"]),
             (ImmutableTestnet, &["immutable-testnet"]),
         ];
 

--- a/src/named.rs
+++ b/src/named.rs
@@ -328,6 +328,14 @@ pub enum NamedChain {
     #[strum(to_string = "pulsechain-testnet")]
     #[cfg_attr(feature = "serde", serde(alias = "pulsechain-testnet"))]
     PulsechainTestnet = 943,
+
+    #[strum(to_string = "immutable")]
+    #[cfg_attr(feature = "serde", serde(alias = "immutable"))]
+    Immutable = 13371,
+    #[strum(to_string = "immutable-testnet")]
+    #[cfg_attr(feature = "serde", serde(alias = "immutable-testnet"))]
+    ImmutableTestnet = 13473,
+
 }
 
 // This must be implemented manually so we avoid a conflict with `TryFromPrimitive` where it treats
@@ -583,6 +591,8 @@ impl NamedChain {
 
             C::Pulsechain => 10000,
             C::PulsechainTestnet => 10101,
+
+            C::Immutable | C::ImmutableTestnet => 2_000,
         }))
     }
 
@@ -696,7 +706,9 @@ impl NamedChain {
             | C::Crab
             | C::Pulsechain
             | C::PulsechainTestnet
-            | C::Koi => false,
+            | C::Koi
+            | C::Immutable
+            | C::ImmutableTestnet => false,
 
             // Unknown / not applicable, default to false for backwards compatibility.
             C::Dev
@@ -786,7 +798,9 @@ impl NamedChain {
             | C::CfxTestnet
             | C::Pulsechain
             | C::PulsechainTestnet
-            | C::Koi => true,
+            | C::Koi
+            | C::Immutable
+            | C::ImmutableTestnet => true,
             _ => false,
         }
     }
@@ -862,7 +876,8 @@ impl NamedChain {
             | C::PulsechainTestnet
             | C::GravityAlphaTestnetSepolia
             | C::XaiSepolia
-            | C::Koi => true,
+            | C::Koi
+            | C::ImmutableTestnet => true,
 
             // Dev chains.
             C::Dev | C::AnvilHardhat => true,
@@ -921,7 +936,8 @@ impl NamedChain {
             | C::Cfx
             | C::Crab
             | C::Pulsechain
-            | C::Etherlink => false,
+            | C::Etherlink
+            | C::Immutable => false,
         }
     }
 
@@ -974,6 +990,9 @@ impl NamedChain {
 
             C::Cfx | C::CfxTestnet => "CFX",
             C::Pulsechain | C::PulsechainTestnet => "PLS",
+
+            C::Immutable => "IMX",
+            C::ImmutableTestnet => "tIMX",
 
             _ => return None,
         })
@@ -1300,6 +1319,12 @@ impl NamedChain {
                 "https://api.scan.v4.testnet.pulsechain.com",
                 "https://scan.v4.testnet.pulsechain.com",
             ),
+
+            C::Immutable => ("https://explorer.immutable.com/api", "https://explorer.immutable.com"),
+            C::ImmutableTestnet => (
+                "https://explorer.testnet.immutable.com/api",
+                "https://explorer.testnet.immutable.com",
+            ),
         })
     }
 
@@ -1399,7 +1424,9 @@ impl NamedChain {
             | C::ZoraSepolia
             | C::Darwinia
             | C::Crab
-            | C::Koi => "BLOCKSCOUT_API_KEY",
+            | C::Koi
+            | C::Immutable
+            | C::ImmutableTestnet => "BLOCKSCOUT_API_KEY",
 
             C::Boba => "BOBASCAN_API_KEY",
 
@@ -1556,6 +1583,7 @@ mod tests {
             (SyndrSepolia, &["syndr-sepolia"]),
             (LineaGoerli, &["linea-goerli"]),
             (AutonomysNovaTestnet, &["autonomys-nova-testnet"]),
+            (ImmutableTestnet, &["immutable-testnet"]),
         ];
 
         for &(chain, aliases) in ALIASES {


### PR DESCRIPTION
PR to add Immutable zkEVM and Immutable zkEVM testnet.

The chain configuration is taken from here: https://docs.immutable.com/platform/zkevm/chain-config/

More information about Immutable can be found here: https://www.immutable.com/  and  https://x.com/Immutable

