### PR TITLE
Update Chain ID for Kakarot Sepolia

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -1381,8 +1381,8 @@
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "5424235787602241": {
-      "internalId": "KakarotStarknetSepolia",
-      "name": "kakarot-starknet-sepolia",
+      "internalId": "KakarotSepolia",
+      "name": "kakarot-sepolia",
       "averageBlocktimeHint": null,
       "isLegacy": false,
       "supportsShanghai": true,

--- a/assets/chains.json
+++ b/assets/chains.json
@@ -1368,18 +1368,6 @@
       "etherscanBaseUrl": "https://testnet.aurorascan.dev",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
-    "1802203764": {
-      "internalId": "KakarotSepolia",
-      "name": "kakarot-sepolia",
-      "averageBlocktimeHint": null,
-      "isLegacy": false,
-      "supportsShanghai": true,
-      "isTestnet": true,
-      "nativeCurrencySymbol": null,
-      "etherscanApiUrl": "https://sepolia.kakarotscan.org/api",
-      "etherscanBaseUrl": "https://sepolia.kakarotscan.org",
-      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
-    },
     "37714555429": {
       "internalId": "XaiSepolia",
       "name": "xai-sepolia",
@@ -1391,6 +1379,18 @@
       "etherscanApiUrl": "https://sepolia.xaiscan.io/api",
       "etherscanBaseUrl": "https://sepolia.xaiscan.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
+    },
+    "5424235787602241": {
+      "internalId": "KakarotStarknetSepolia",
+      "name": "kakarot-starknet-sepolia",
+      "averageBlocktimeHint": null,
+      "isLegacy": false,
+      "supportsShanghai": true,
+      "isTestnet": true,
+      "nativeCurrencySymbol": null,
+      "etherscanApiUrl": "https://sepolia.kakarotscan.org/api",
+      "etherscanBaseUrl": "https://sepolia.kakarotscan.org",
+      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
     }
   }
 }

--- a/src/named.rs
+++ b/src/named.rs
@@ -600,7 +600,7 @@ impl NamedChain {
             Morden | Ropsten | Rinkeby | Goerli | Kovan | Sepolia | Holesky | MantleTestnet
             | Moonbase | MoonbeamDev | OptimismKovan | Poa | Sokol | Rsk | EmeraldTestnet
             | Boba | ZkSync | ZkSyncTestnet | PolygonZkEvm | PolygonZkEvmTestnet | Metis
-            | Linea | LineaGoerli | KakarotSepolia  => return None,
+            | Linea | LineaGoerli | KakarotSepolia => return None,
         }))
     }
 

--- a/src/named.rs
+++ b/src/named.rs
@@ -280,8 +280,8 @@ pub enum NamedChain {
 
     Elastos = 20,
 
-    #[cfg_attr(feature = "serde", serde(alias = "kakarot-sepolia"))]
-    KakarotSepolia = 1802203764,
+    #[cfg_attr(feature = "serde", serde(alias = "kakarot-starknet-sepolia"))]
+    KakarotStarknetSepolia = 5424235787602241,
 
     #[cfg_attr(feature = "serde", serde(alias = "etherlink"))]
     Etherlink = 42793,
@@ -600,7 +600,7 @@ impl NamedChain {
             Morden | Ropsten | Rinkeby | Goerli | Kovan | Sepolia | Holesky | MantleTestnet
             | Moonbase | MoonbeamDev | OptimismKovan | Poa | Sokol | Rsk | EmeraldTestnet
             | Boba | ZkSync | ZkSyncTestnet | PolygonZkEvm | PolygonZkEvmTestnet | Metis
-            | Linea | LineaGoerli | KakarotSepolia => return None,
+            | Linea | LineaGoerli | KakarotStarknetSepolia => return None,
         }))
     }
 
@@ -695,7 +695,7 @@ impl NamedChain {
             | ModeSepolia
             | Pgn
             | PgnSepolia
-            | KakarotSepolia
+            | KakarotStarknetSepolia
             | Etherlink
             | EtherlinkTestnet
             | Degen
@@ -773,7 +773,7 @@ impl NamedChain {
                 | Shimmer
                 | OpBNBMainnet
                 | OpBNBTestnet
-                | KakarotSepolia
+                | KakarotStarknetSepolia
                 | Taiko
                 | TaikoHekla
                 | Avalanche
@@ -848,7 +848,7 @@ impl NamedChain {
             | ZoraSepolia
             | ModeSepolia
             | PgnSepolia
-            | KakarotSepolia
+            | KakarotStarknetSepolia
             | EtherlinkTestnet
             | OpBNBTestnet
             | TaikoHekla
@@ -1165,7 +1165,7 @@ impl NamedChain {
             | AutonomysNovaTestnet => {
                 return None;
             }
-            KakarotSepolia => {
+            KakarotStarknetSepolia => {
                 ("https://sepolia.kakarotscan.org/api", "https://sepolia.kakarotscan.org")
             }
             Etherlink => ("https://explorer.etherlink.com/api", "https://explorer.etherlink.com"),
@@ -1299,7 +1299,7 @@ impl NamedChain {
             Moonbeam | Moonbase | MoonbeamDev | Moonriver => "MOONSCAN_API_KEY",
 
             Acala | AcalaMandalaTestnet | AcalaTestnet | Canto | CantoTestnet | Etherlink
-            | EtherlinkTestnet | Flare | FlareCoston2 | KakarotSepolia | Karura | KaruraTestnet
+            | EtherlinkTestnet | Flare | FlareCoston2 | KakarotStarknetSepolia | Karura | KaruraTestnet
             | Mode | ModeSepolia | Pgn | PgnSepolia | Shimmer | Zora | ZoraGoerli | ZoraSepolia
             | Darwinia | Crab | Koi | Immutable | ImmutableTestnet => "BLOCKSCOUT_API_KEY",
 

--- a/src/named.rs
+++ b/src/named.rs
@@ -280,8 +280,8 @@ pub enum NamedChain {
 
     Elastos = 20,
 
-    #[cfg_attr(feature = "serde", serde(alias = "kakarot-starknet-sepolia"))]
-    KakarotStarknetSepolia = 5424235787602241,
+    #[cfg_attr(feature = "serde", serde(alias = "kakarot-sepolia", alias = "kakarot-starknet-sepolia"))]
+    KakarotSepolia = 5424235787602241,
 
     #[cfg_attr(feature = "serde", serde(alias = "etherlink"))]
     Etherlink = 42793,
@@ -600,7 +600,7 @@ impl NamedChain {
             Morden | Ropsten | Rinkeby | Goerli | Kovan | Sepolia | Holesky | MantleTestnet
             | Moonbase | MoonbeamDev | OptimismKovan | Poa | Sokol | Rsk | EmeraldTestnet
             | Boba | ZkSync | ZkSyncTestnet | PolygonZkEvm | PolygonZkEvmTestnet | Metis
-            | Linea | LineaGoerli | KakarotStarknetSepolia => return None,
+            | Linea | LineaGoerli | KakarotSepolia  => return None,
         }))
     }
 
@@ -695,7 +695,7 @@ impl NamedChain {
             | ModeSepolia
             | Pgn
             | PgnSepolia
-            | KakarotStarknetSepolia
+            | KakarotSepolia
             | Etherlink
             | EtherlinkTestnet
             | Degen
@@ -773,7 +773,7 @@ impl NamedChain {
                 | Shimmer
                 | OpBNBMainnet
                 | OpBNBTestnet
-                | KakarotStarknetSepolia
+                | KakarotSepolia
                 | Taiko
                 | TaikoHekla
                 | Avalanche
@@ -848,7 +848,7 @@ impl NamedChain {
             | ZoraSepolia
             | ModeSepolia
             | PgnSepolia
-            | KakarotStarknetSepolia
+            | KakarotSepolia
             | EtherlinkTestnet
             | OpBNBTestnet
             | TaikoHekla
@@ -1165,7 +1165,7 @@ impl NamedChain {
             | AutonomysNovaTestnet => {
                 return None;
             }
-            KakarotStarknetSepolia => {
+            KakarotSepolia => {
                 ("https://sepolia.kakarotscan.org/api", "https://sepolia.kakarotscan.org")
             }
             Etherlink => ("https://explorer.etherlink.com/api", "https://explorer.etherlink.com"),
@@ -1299,7 +1299,7 @@ impl NamedChain {
             Moonbeam | Moonbase | MoonbeamDev | Moonriver => "MOONSCAN_API_KEY",
 
             Acala | AcalaMandalaTestnet | AcalaTestnet | Canto | CantoTestnet | Etherlink
-            | EtherlinkTestnet | Flare | FlareCoston2 | KakarotStarknetSepolia | Karura | KaruraTestnet
+            | EtherlinkTestnet | Flare | FlareCoston2 | KakarotSepolia | Karura | KaruraTestnet
             | Mode | ModeSepolia | Pgn | PgnSepolia | Shimmer | Zora | ZoraGoerli | ZoraSepolia
             | Darwinia | Crab | Koi | Immutable | ImmutableTestnet => "BLOCKSCOUT_API_KEY",
 

--- a/src/named.rs
+++ b/src/named.rs
@@ -280,7 +280,10 @@ pub enum NamedChain {
 
     Elastos = 20,
 
-    #[cfg_attr(feature = "serde", serde(alias = "kakarot-sepolia", alias = "kakarot-starknet-sepolia"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(alias = "kakarot-sepolia", alias = "kakarot-starknet-sepolia")
+    )]
     KakarotSepolia = 5424235787602241,
 
     #[cfg_attr(feature = "serde", serde(alias = "etherlink"))]


### PR DESCRIPTION
Updates network configuration for Kakarot's launch on Starknet Sepolia:

**Chain ID:** `1802203764` → `5424235787602241`
**Chain name:** `KakarotSepolia` → `KakarotStarknetSepolia`
**Network alias:** `kakarot-sepolia` → `kakarot-starknet-sepolia`

This PR updates all relevant references throughout the codebase.