### PR TITLE
update kakarot starknet sepolia

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -1392,7 +1392,7 @@
       "etherscanBaseUrl": "https://sepolia.xaiscan.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
-    "5424235787602241": {
+    "920637907288165": {
       "internalId": "KakarotSepolia",
       "name": "kakarot-sepolia",
       "averageBlocktimeHint": null,

--- a/src/named.rs
+++ b/src/named.rs
@@ -284,7 +284,7 @@ pub enum NamedChain {
         feature = "serde",
         serde(alias = "kakarot-sepolia", alias = "kakarot-starknet-sepolia")
     )]
-    KakarotSepolia = 5424235787602241,
+    KakarotSepolia = 920637907288165,
 
     #[cfg_attr(feature = "serde", serde(alias = "etherlink"))]
     Etherlink = 42793,


### PR DESCRIPTION
This PR updates Kakarot starknet sepolia chain id from `5424235787602241` to `920637907288165`