### PR TITLE
feat(`NamedChain`): is_arbitrum

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -504,6 +504,12 @@ impl Chain {
         matches!(self.named(), Some(named) if named.is_optimism())
     }
 
+    /// Returns true if the chain contains Arbitrum configuration.
+    #[inline]
+    pub const fn is_arbitrum(self) -> bool {
+        matches!(self.named(), Some(named) if named.is_arbitrum())
+    }
+
     /// Attempts to convert the chain into a named chain.
     #[inline]
     pub const fn named(self) -> Option<NamedChain> {

--- a/src/named.rs
+++ b/src/named.rs
@@ -518,6 +518,13 @@ impl NamedChain {
         )
     }
 
+    /// Returns true if the chain contains Arbitrum configuration.
+    pub const fn is_arbitrum(self) -> bool {
+        use NamedChain::*;
+
+        matches!(self, Arbitrum | ArbitrumTestnet | ArbitrumGoerli | ArbitrumSepolia | ArbitrumNova)
+    }
+
     /// Returns the chain's average blocktime, if applicable.
     ///
     /// It can be beneficial to know the average blocktime to adjust the polling of an HTTP provider


### PR DESCRIPTION
Adds helper method to check if `NamedChain` belongs to the Arbitrum configuration