### PR TITLE
fix: update explorer API endpoint for `Celo` / `CeloAlfajores` to use Etherscan

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -1040,8 +1040,8 @@
       "supportsShanghai": false,
       "isTestnet": false,
       "nativeCurrencySymbol": null,
-      "etherscanApiUrl": "https://explorer.celo.org/mainnet/api",
-      "etherscanBaseUrl": "https://explorer.celo.org/mainnet",
+      "etherscanApiUrl": "https://api.celoscan.io/api",
+      "etherscanBaseUrl": "https://celoscan.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "42261": {
@@ -1112,8 +1112,8 @@
       "supportsShanghai": false,
       "isTestnet": true,
       "nativeCurrencySymbol": null,
-      "etherscanApiUrl": "https://explorer.celo.org/alfajores/api",
-      "etherscanBaseUrl": "https://explorer.celo.org/alfajores",
+      "etherscanApiUrl": "https://api-alfajores.celoscan.io/api",
+      "etherscanBaseUrl": "https://alfajores.celoscan.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "58008": {
@@ -1174,7 +1174,7 @@
       "nativeCurrencySymbol": null,
       "etherscanApiUrl": "https://explorer.celo.org/baklava/api",
       "etherscanBaseUrl": "https://explorer.celo.org/baklava",
-      "etherscanApiKeyName": "ETHERSCAN_API_KEY"
+      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
     },
     "80001": {
       "internalId": "PolygonMumbai",

--- a/src/named.rs
+++ b/src/named.rs
@@ -1183,9 +1183,9 @@ impl NamedChain {
             Evmos => ("https://evm.evmos.org/api", "https://evm.evmos.org"),
             EvmosTestnet => ("https://evm.evmos.dev/api", "https://evm.evmos.dev"),
 
-            Celo => ("https://explorer.celo.org/mainnet/api", "https://explorer.celo.org/mainnet"),
+            Celo => ("https://api.celoscan.io/api", "https://celoscan.io"),
             CeloAlfajores => {
-                ("https://explorer.celo.org/alfajores/api", "https://explorer.celo.org/alfajores")
+                ("https://api-alfajores.celoscan.io/api", "https://alfajores.celoscan.io")
             }
             CeloBaklava => {
                 ("https://explorer.celo.org/baklava/api", "https://explorer.celo.org/baklava")
@@ -1391,7 +1391,6 @@ impl NamedChain {
             | AuroraTestnet
             | Celo
             | CeloAlfajores
-            | CeloBaklava
             | Base
             | Linea
             | LineaSepolia
@@ -1424,11 +1423,13 @@ impl NamedChain {
 
             Moonbeam | Moonbase | MoonbeamDev | Moonriver => "MOONSCAN_API_KEY",
 
-            Acala | AcalaMandalaTestnet | AcalaTestnet | Canto | CantoTestnet | Etherlink
-            | EtherlinkTestnet | Flare | FlareCoston2 | KakarotSepolia | Karura | KaruraTestnet
-            | Mode | ModeSepolia | Pgn | PgnSepolia | Shimmer | Zora | ZoraGoerli | ZoraSepolia
-            | Darwinia | Crab | Koi | Immutable | ImmutableTestnet | SoneiumMinatoTestnet
-            | World | WorldSepolia | Curtis | InkSepolia => "BLOCKSCOUT_API_KEY",
+            Acala | AcalaMandalaTestnet | AcalaTestnet | Canto | CantoTestnet | CeloBaklava
+            | Etherlink | EtherlinkTestnet | Flare | FlareCoston2 | KakarotSepolia | Karura
+            | KaruraTestnet | Mode | ModeSepolia | Pgn | PgnSepolia | Shimmer | Zora
+            | ZoraGoerli | ZoraSepolia | Darwinia | Crab | Koi | Immutable | ImmutableTestnet
+            | SoneiumMinatoTestnet | World | WorldSepolia | Curtis | InkSepolia => {
+                "BLOCKSCOUT_API_KEY"
+            }
 
             Boba => "BOBASCAN_API_KEY",
 


### PR DESCRIPTION
- Update Celo / CeloAlfajores with correct Etherscan URL
- Correctly identify `Celo Baklava` as using Blockscout