### PR TITLE
Update World Chain urls

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -439,10 +439,10 @@
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": false,
-      "nativeCurrencySymbol": null,
+      "nativeCurrencySymbol": "WRLD",
       "etherscanApiUrl": "https://api.worldscan.org/api",
-      "etherscanBaseUrl": "https://worldscan.org/",
-      "etherscanApiKeyName": "ETHERSCAN_API_KEY"
+      "etherscanBaseUrl": "https://worldscan.org",
+      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
     },
     "595": {
       "internalId": "AcalaMandalaTestnet",
@@ -787,10 +787,10 @@
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": true,
-      "nativeCurrencySymbol": null,
+      "nativeCurrencySymbol": "WRLD",
       "etherscanApiUrl": "https://api-sepolia.worldscan.org/api",
-      "etherscanBaseUrl": "https://sepolia.worldscan.org/",
-      "etherscanApiKeyName": "ETHERSCAN_API_KEY"
+      "etherscanBaseUrl": "https://sepolia.worldscan.org",
+      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
     },
     "5000": {
       "internalId": "Mantle",

--- a/assets/chains.json
+++ b/assets/chains.json
@@ -439,10 +439,10 @@
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": false,
-      "nativeCurrencySymbol": "WRLD",
-      "etherscanApiUrl": "https://worldchain-mainnet.explorer.alchemy.com/api",
-      "etherscanBaseUrl": "https://worldchain-mainnet.explorer.alchemy.com",
-      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
+      "nativeCurrencySymbol": null,
+      "etherscanApiUrl": "https://api.worldscan.org/api",
+      "etherscanBaseUrl": "https://worldscan.org/",
+      "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "595": {
       "internalId": "AcalaMandalaTestnet",
@@ -787,10 +787,10 @@
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": true,
-      "nativeCurrencySymbol": "WRLD",
-      "etherscanApiUrl": "https://worldchain-sepolia.explorer.alchemy.com/api",
-      "etherscanBaseUrl": "https://worldchain-sepolia.explorer.alchemy.com",
-      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
+      "nativeCurrencySymbol": null,
+      "etherscanApiUrl": "https://api-sepolia.worldscan.org/api",
+      "etherscanBaseUrl": "https://sepolia.worldscan.org/",
+      "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "5000": {
       "internalId": "Mantle",

--- a/src/named.rs
+++ b/src/named.rs
@@ -1331,7 +1331,7 @@ impl NamedChain {
             }
             World => (
                 "https://api.worldscan.org/api",
-                "https://worldscan.org/"
+                "https://worldscan.org"
             ),
             WorldSepolia => (
                 "https://api-sepolia.worldscan.org/api",

--- a/src/named.rs
+++ b/src/named.rs
@@ -1329,14 +1329,10 @@ impl NamedChain {
             Odyssey => {
                 ("https://odyssey-explorer.ithaca.xyz/api", "https://odyssey-explorer.ithaca.xyz")
             }
-            World => (
-                "https://api.worldscan.org/api",
-                "https://worldscan.org"
-            ),
-            WorldSepolia => (
-                "https://api-sepolia.worldscan.org/api",
-                "https://sepolia.worldscan.org",
-            ),
+            World => ("https://api.worldscan.org/api", "https://worldscan.org"),
+            WorldSepolia => {
+                ("https://api-sepolia.worldscan.org/api", "https://sepolia.worldscan.org")
+            }
             UnichainSepolia => {
                 ("https://sepolia.uniscan.xyz", "https://api-sepolia.uniscan.xyz/api")
             }

--- a/src/named.rs
+++ b/src/named.rs
@@ -1335,7 +1335,7 @@ impl NamedChain {
             ),
             WorldSepolia => (
                 "https://api-sepolia.worldscan.org/api",
-                "https://sepolia.worldscan.org/",
+                "https://sepolia.worldscan.org",
             ),
             UnichainSepolia => {
                 ("https://sepolia.uniscan.xyz", "https://api-sepolia.uniscan.xyz/api")

--- a/src/named.rs
+++ b/src/named.rs
@@ -1330,12 +1330,12 @@ impl NamedChain {
                 ("https://odyssey-explorer.ithaca.xyz/api", "https://odyssey-explorer.ithaca.xyz")
             }
             World => (
-                "https://worldchain-mainnet.explorer.alchemy.com/api",
-                "https://worldchain-mainnet.explorer.alchemy.com",
+                "https://api.worldscan.org/api",
+                "https://worldscan.org/"
             ),
             WorldSepolia => (
-                "https://worldchain-sepolia.explorer.alchemy.com/api",
-                "https://worldchain-sepolia.explorer.alchemy.com",
+                "https://api-sepolia.worldscan.org/api",
+                "https://sepolia.worldscan.org/",
             ),
             UnichainSepolia => {
                 ("https://sepolia.uniscan.xyz", "https://api-sepolia.uniscan.xyz/api")


### PR DESCRIPTION
Updates the World Chain urls to use worldscan.org instead of explorer.alchemy.com.

Also removes the `nativeCurrencySymbol` for World Chain and World Chain Sepolia
