### PR TITLE
chore: Update BSC poll interval to reflect BSC block time

### DIFF
--- a/src/named.rs
+++ b/src/named.rs
@@ -766,7 +766,7 @@ impl NamedChain {
             Acala | AcalaMandalaTestnet | AcalaTestnet | Karura | KaruraTestnet | Moonbeam
             | Moonriver => 12_500,
 
-            BinanceSmartChain | BinanceSmartChainTestnet => 3_000,
+            BinanceSmartChain | BinanceSmartChainTestnet => 750,
 
             Avalanche | AvalancheFuji => 2_000,
 


### PR DESCRIPTION
Update BSC poll interval to reflect BSC block time. Currently is set at 3 seconds which is way too long. 

Not sure if `0.75s` is desired tho. If somebody is relying that provider polls every `3s` and now starts polling `0.75s` they could start hitting rate limits, and their program could stop working. Not sure what is the best approach here, but would be great if it was made shorter.