### PR TITLE
fix: Sonic Blaze deprecated, Sonic Testnet chain id update, explorer URL update

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -346,7 +346,7 @@
       "nativeCurrencySymbol": "S",
       "etherscanApiUrl": "https://api.etherscan.io/v2/api?chainid=146",
       "etherscanBaseUrl": "https://sonicscan.org",
-      "etherscanApiKeyName": "SONICSCAN_API_KEY"
+      "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "148": {
       "internalId": "Shimmer",
@@ -1176,6 +1176,18 @@
       "etherscanBaseUrl": "https://explorer-sepolia.gravity.xyz",
       "etherscanApiKeyName": null
     },
+    "14601": {
+      "internalId": "SonicTestnet",
+      "name": "sonic-testnet",
+      "averageBlocktimeHint": 1000,
+      "isLegacy": false,
+      "supportsShanghai": false,
+      "isTestnet": true,
+      "nativeCurrencySymbol": "S",
+      "etherscanApiUrl": "https://api.etherscan.io/v2/api?chainid=14601",
+      "etherscanBaseUrl": "https://testnet.sonicscan.org",
+      "etherscanApiKeyName": "ETHERSCAN_API_KEY"
+    },
     "17000": {
       "internalId": "Holesky",
       "name": "holesky",
@@ -1416,18 +1428,6 @@
       "etherscanBaseUrl": "https://explorer.superposition.so",
       "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
     },
-    "57054": {
-      "internalId": "SonicBlaze",
-      "name": "sonic-blaze",
-      "averageBlocktimeHint": null,
-      "isLegacy": false,
-      "supportsShanghai": false,
-      "isTestnet": true,
-      "nativeCurrencySymbol": "S",
-      "etherscanApiUrl": "https://api.etherscan.io/v2/api?chainid=57054",
-      "etherscanBaseUrl": "https://testnet.sonicscan.org",
-      "etherscanApiKeyName": null
-    },
     "57073": {
       "internalId": "Ink",
       "name": "ink",
@@ -1523,18 +1523,6 @@
       "etherscanApiUrl": null,
       "etherscanBaseUrl": null,
       "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
-    },
-    "64165": {
-      "internalId": "SonicTestnet",
-      "name": "sonic-testnet",
-      "averageBlocktimeHint": null,
-      "isLegacy": false,
-      "supportsShanghai": false,
-      "isTestnet": true,
-      "nativeCurrencySymbol": null,
-      "etherscanApiUrl": "https://api.routescan.io/v2/network/testnet/evm/64165/etherscan/api",
-      "etherscanBaseUrl": "https://scan.soniclabs.com",
-      "etherscanApiKeyName": null
     },
     "80001": {
       "internalId": "PolygonMumbai",

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -589,10 +589,10 @@ impl Chain {
         Self::from_named(NamedChain::Sonic)
     }
 
-    /// Returns the Sonic Blaze testnet chain.
+    /// Returns the Sonic testnet chain.
     #[inline]
-    pub const fn sonic_blaze() -> Self {
-        Self::from_named(NamedChain::SonicBlaze)
+    pub const fn sonic_testnet() -> Self {
+        Self::from_named(NamedChain::SonicTestnet)
     }
 
     /// Returns the Superposition testnet chain.

--- a/src/named.rs
+++ b/src/named.rs
@@ -419,15 +419,12 @@ pub enum NamedChain {
     #[cfg_attr(feature = "serde", serde(alias = "apechain-testnet", alias = "curtis"))]
     Curtis = 33111,
 
-    #[strum(to_string = "sonic-blaze")]
-    #[cfg_attr(feature = "serde", serde(alias = "sonic-blaze"))]
-    SonicBlaze = 57054,
-    #[strum(to_string = "sonic-testnet")]
-    #[cfg_attr(feature = "serde", serde(alias = "sonic-testnet"))]
-    SonicTestnet = 64165,
     #[strum(to_string = "sonic")]
     #[cfg_attr(feature = "serde", serde(alias = "sonic"))]
     Sonic = 146,
+    #[strum(to_string = "sonic-testnet")]
+    #[cfg_attr(feature = "serde", serde(alias = "sonic-testnet"))]
+    SonicTestnet = 14601,
 
     #[strum(to_string = "treasure")]
     #[cfg_attr(feature = "serde", serde(alias = "treasure"))]
@@ -839,7 +836,7 @@ impl NamedChain {
             Story => 2_500,
             Sei => 500,
 
-            Sonic => 1_000,
+            Sonic | SonicTestnet => 1_000,
 
             TelosEvm | TelosEvmTestnet => 500,
 
@@ -866,7 +863,7 @@ impl NamedChain {
             Morden | Ropsten | Rinkeby | Goerli | Kovan | Sepolia | Holesky | Hoodi | Moonbase
             | MoonbeamDev | OptimismKovan | Poa | Sokol | EmeraldTestnet | Boba | PolygonZkEvm
             | PolygonZkEvmTestnet | Metis | Linea | LineaGoerli | LineaSepolia | KakarotSepolia
-            | SonicBlaze | SonicTestnet | Treasure | TreasureTopaz | Corn | CornTestnet => {
+            | Treasure | TreasureTopaz | Corn | CornTestnet => {
                 return None;
             }
         }))
@@ -977,6 +974,7 @@ impl NamedChain {
             | Soneium
             | SoneiumMinatoTestnet
             | Sonic
+            | SonicTestnet
             | World
             | WorldSepolia
             | Unichain
@@ -1010,8 +1008,8 @@ impl NamedChain {
             Dev | AnvilHardhat | Morden | Ropsten | Rinkeby | Cronos | CronosTestnet | Kovan
             | Sokol | Poa | Moonbeam | MoonbeamDev | Moonriver | Moonbase | Evmos
             | EvmosTestnet | Aurora | AuroraTestnet | Canto | CantoTestnet | Iotex | Core
-            | Merlin | Bitlayer | SonicBlaze | SonicTestnet | Vana | Zeta | Kaia | Story | Sei
-            | Injective | InjectiveTestnet | Katana | Lisk | Fuse => false,
+            | Merlin | Bitlayer | Vana | Zeta | Kaia | Story | Sei | Injective
+            | InjectiveTestnet | Katana | Lisk | Fuse => false,
         }
     }
 
@@ -1186,7 +1184,6 @@ impl NamedChain {
             | UnichainSepolia
             | Curtis
             | TreasureTopaz
-            | SonicBlaze
             | SonicTestnet
             | BerachainBepolia
             | SuperpositionTestnet
@@ -1283,7 +1280,7 @@ impl NamedChain {
 
             BerachainBepolia | Berachain => "BERA",
 
-            Sonic | SonicBlaze => "S",
+            Sonic | SonicTestnet => "S",
 
             TelosEvm | TelosEvmTestnet => "TLOS",
 
@@ -1572,14 +1569,10 @@ impl NamedChain {
             Curtis => {
                 ("https://api.etherscan.io/v2/api?chainid=33111", "https://curtis.apescan.io")
             }
-            SonicBlaze => {
-                ("https://api.etherscan.io/v2/api?chainid=57054", "https://testnet.sonicscan.org")
-            }
-            SonicTestnet => (
-                "https://api.routescan.io/v2/network/testnet/evm/64165/etherscan/api",
-                "https://scan.soniclabs.com",
-            ),
             Sonic => ("https://api.etherscan.io/v2/api?chainid=146", "https://sonicscan.org"),
+            SonicTestnet => {
+                ("https://api.etherscan.io/v2/api?chainid=14601", "https://testnet.sonicscan.org")
+            }
             BerachainBepolia => {
                 ("https://api.etherscan.io/v2/api?chainid=80069", "https://testnet.berascan.com")
             }
@@ -1709,6 +1702,8 @@ impl NamedChain {
             | Blast
             | BlastSepolia
             | Gnosis
+            | Sonic
+            | SonicTestnet
             | Scroll
             | ScrollSepolia
             | Taiko
@@ -1750,7 +1745,6 @@ impl NamedChain {
             Bitlayer => "BITLAYERSCAN_API_KEY",
             Zeta => "ZETASCAN_API_KEY",
             Kaia => "KAIASCAN_API_KEY",
-            Sonic => "SONICSCAN_API_KEY",
             Berachain | BerachainBepolia => "BERASCAN_API_KEY",
             Corn | CornTestnet => "ROUTESCAN_API_KEY",
             // Explicitly exhaustive. See NB above.
@@ -1788,8 +1782,6 @@ impl NamedChain {
             | AutonomysNovaTestnet
             | Iotex
             | HappychainTestnet
-            | SonicBlaze
-            | SonicTestnet
             | Treasure
             | TreasureTopaz
             | TelosEvm


### PR DESCRIPTION
Update applied according to information on https://docs.soniclabs.com/sonic/build-on-sonic/getting-started

Closes #201 

Deprecated Sonic Blaze as it has no explorer URL available (just redirects to Sonic Testnet which has a different chain id)