### PR TITLE
fix: update Katana URLs

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -1736,8 +1736,8 @@
       "supportsShanghai": false,
       "isTestnet": false,
       "nativeCurrencySymbol": "ETH",
-      "etherscanApiUrl": "https://explorer.katanarpc.com/api",
-      "etherscanBaseUrl": "https://explorer.katanarpc.com",
+      "etherscanApiUrl": "https://api.etherscan.io/v2/api?chainid=747474",
+      "etherscanBaseUrl": "https://katanascan.com",
       "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
     },
     "763373": {

--- a/src/named.rs
+++ b/src/named.rs
@@ -1576,7 +1576,7 @@ impl NamedChain {
                 "https://block-explorer-api.staging.lens.zksync.dev",
                 "https://explorer.testnet.lens.xyz",
             ),
-            Katana => ("https://explorer.katanarpc.com/api", "https://explorer.katanarpc.com"),
+            Katana => ("https://api.etherscan.io/v2/api?chainid=747474", "https://katanascan.com"),
             Lisk => ("https://blockscout.lisk.com/api", "https://blockscout.lisk.com"),
             Fuse => ("https://explorer.fuse.io/api", "https://explorer.fuse.io"),
             Injective => (


### PR DESCRIPTION
- update API to etherscan V2
- update blockexpolrer to https://katanascan.com