### PR TITLE
fix: Katana now requires an `ETHERSCAN_API_KEY`

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -1738,7 +1738,7 @@
       "nativeCurrencySymbol": "ETH",
       "etherscanApiUrl": "https://api.etherscan.io/v2/api?chainid=747474",
       "etherscanBaseUrl": "https://katanascan.com",
-      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
+      "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "763373": {
       "internalId": "InkSepolia",

--- a/src/named.rs
+++ b/src/named.rs
@@ -1647,6 +1647,7 @@ impl NamedChain {
             | Holesky
             | Hoodi
             | Hyperliquid
+            | Katana
             | Kovan
             | Linea
             | LineaSepolia
@@ -1691,8 +1692,9 @@ impl NamedChain {
             | Mode | ModeSepolia | Pgn | PgnSepolia | Shimmer | Zora | ZoraSepolia | Darwinia
             | Crab | Koi | Immutable | ImmutableTestnet | Soneium | SoneiumMinatoTestnet
             | World | WorldSepolia | Curtis | Ink | InkSepolia | SuperpositionTestnet
-            | Superposition | Vana | Story | Katana | Lisk | Fuse | Injective
-            | InjectiveTestnet => "BLOCKSCOUT_API_KEY",
+            | Superposition | Vana | Story | Lisk | Fuse | Injective | InjectiveTestnet => {
+                "BLOCKSCOUT_API_KEY"
+            }
 
             Boba => "BOBASCAN_API_KEY",
 


### PR DESCRIPTION
Follow up of https://github.com/alloy-rs/chains/pull/207, a nice to have

Can be included in the next release