### PR TITLE
chore: update MSRV in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ When updating this, also update:
 
 Alloy will keep a rolling MSRV (minimum supported rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
-released at least six months ago. The current MSRV is 1.81.0.
+released at least six months ago. The current MSRV is 1.85.0.
 
 Note that the MSRV is not increased automatically, and only as part of a minor
 release.


### PR DESCRIPTION
This is now 1.85 per https://github.com/alloy-rs/chains/blob/59f78449f4c7b6e72ae583c3dfd54acf805042f5/Cargo.toml#L6 & https://github.com/alloy-rs/chains/blob/59f78449f4c7b6e72ae583c3dfd54acf805042f5/clippy.toml#L1