### PR TITLE
chore: update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @danipopes @mattsse @zerosnacks @yash-atreya
+* @danipopes @mattsse @klkvr @onbjerg @zerosnacks @grandizzy


### PR DESCRIPTION
aligns with: https://github.com/alloy-rs/alloy/blob/main/.github/CODEOWNERS