### PR TITLE
fix: update celo sepolia api to etherscan

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -1856,8 +1856,8 @@
       "supportsShanghai": true,
       "isTestnet": true,
       "nativeCurrencySymbol": "CELO",
-      "etherscanApiUrl": "https://celo-sepolia.blockscout.com/api",
-      "etherscanBaseUrl": "https://celo-sepolia.blockscout.com",
+      "etherscanApiUrl": "https://api.etherscan.io/v2/api?chainid=11142220",
+      "etherscanBaseUrl": "https://sepolia.celoscan.io",
       "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
     },
     "11155111": {

--- a/src/named.rs
+++ b/src/named.rs
@@ -1440,7 +1440,7 @@ impl NamedChain {
             }
             Celo => ("https://api.etherscan.io/v2/api?chainid=42220", "https://celoscan.io"),
             CeloSepolia => {
-                ("https://celo-sepolia.blockscout.com/api", "https://celo-sepolia.blockscout.com")
+                ("https://api.etherscan.io/v2/api?chainid=11142220", "https://sepolia.celoscan.io")
             }
             Boba => ("https://api.bobascan.com/api", "https://bobascan.com"),
             Base => ("https://api.etherscan.io/v2/api?chainid=8453", "https://basescan.org"),


### PR DESCRIPTION
ref https://github.com/foundry-rs/foundry/issues/12360, update celo sepolia api url to etherscan, shows as supported in https://docs.etherscan.io/supported-chains