### PR TITLE
Adds Polkadot Testnet

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -723,7 +723,7 @@
     "1284": {
       "internalId": "Moonbeam",
       "name": "moonbeam",
-      "averageBlocktimeHint": 12500,
+      "averageBlocktimeHint": 6500,
       "isLegacy": false,
       "supportsShanghai": false,
       "isTestnet": false,
@@ -735,7 +735,7 @@
     "1285": {
       "internalId": "Moonriver",
       "name": "moonriver",
-      "averageBlocktimeHint": 12500,
+      "averageBlocktimeHint": 6500,
       "isLegacy": false,
       "supportsShanghai": false,
       "isTestnet": false,
@@ -1919,6 +1919,18 @@
       "etherscanApiUrl": "https://api.etherscan.io/v2/api?chainid=168587773",
       "etherscanBaseUrl": "https://sepolia.blastscan.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
+    },
+    "420420417": {
+      "internalId": "PolkadotTestnet",
+      "name": "polkadot-testnet",
+      "averageBlocktimeHint": null,
+      "isLegacy": false,
+      "supportsShanghai": false,
+      "isTestnet": true,
+      "nativeCurrencySymbol": null,
+      "etherscanApiUrl": null,
+      "etherscanBaseUrl": null,
+      "etherscanApiKeyName": null
     },
     "531050104": {
       "internalId": "SophonTestnet",

--- a/src/named.rs
+++ b/src/named.rs
@@ -473,6 +473,10 @@ pub enum NamedChain {
     #[cfg_attr(feature = "serde", serde(alias = "sophon-testnet"))]
     SophonTestnet = 531050104,
 
+    #[strum(to_string = "polkadot-testnet")]
+    #[cfg_attr(feature = "serde", serde(alias = "polkadot-testnet"))]
+    PolkadotTestnet = 420420417,
+
     #[strum(to_string = "lens")]
     #[cfg_attr(feature = "serde", serde(alias = "lens"))]
     Lens = 232,
@@ -764,8 +768,9 @@ impl NamedChain {
 
             Polygon | PolygonAmoy => 2_100,
 
-            Acala | AcalaMandalaTestnet | AcalaTestnet | Karura | KaruraTestnet | Moonbeam
-            | Moonriver => 12_500,
+            Acala | AcalaMandalaTestnet | AcalaTestnet | Karura | KaruraTestnet => 12_500,
+
+            Moonbeam | Moonriver => 6_500,
 
             BinanceSmartChain | BinanceSmartChainTestnet => 750,
 
@@ -857,7 +862,7 @@ impl NamedChain {
             Morden | Ropsten | Rinkeby | Goerli | Kovan | Sepolia | Holesky | Hoodi | Moonbase
             | MoonbeamDev | OptimismKovan | Poa | Sokol | EmeraldTestnet | Boba | Metis | Linea
             | LineaGoerli | LineaSepolia | Treasure | TreasureTopaz | Corn | CornTestnet
-            | Cannon => {
+            | Cannon | PolkadotTestnet => {
                 return None;
             }
         }))
@@ -1003,7 +1008,7 @@ impl NamedChain {
             | Sokol | Poa | Moonbeam | MoonbeamDev | Moonriver | Moonbase | Evmos
             | EvmosTestnet | Aurora | AuroraTestnet | Canto | CantoTestnet | Iotex | Core
             | Merlin | Bitlayer | Vana | Zeta | Kaia | Story | Sei | SeiTestnet | Injective
-            | InjectiveTestnet | Katana | Lisk | Fuse | Cannon => false,
+            | InjectiveTestnet | Katana | Lisk | Fuse | Cannon | PolkadotTestnet => false,
         }
     }
 
@@ -1186,6 +1191,7 @@ impl NamedChain {
             | AbstractTestnet
             | LensTestnet
             | SophonTestnet
+            | PolkadotTestnet
             | InjectiveTestnet
             | FluentDevnet
             | FluentTestnet
@@ -1640,7 +1646,7 @@ impl NamedChain {
             | Evmos | EvmosTestnet | Fantom | FantomTestnet | FilecoinMainnet | Goerli | Iotex
             | KaruraTestnet | Koi | Kovan | LineaGoerli | MoonbeamDev | Morden | Oasis
             | OptimismGoerli | OptimismKovan | Pgn | PgnSepolia | Poa | Rinkeby | Ropsten
-            | Sokol | Treasure | TreasureTopaz | Cannon => {
+            | Sokol | Treasure | TreasureTopaz | Cannon | PolkadotTestnet => {
                 return None;
             }
         })
@@ -1791,7 +1797,8 @@ impl NamedChain {
             | LensTestnet
             | FluentDevnet
             | FluentTestnet
-            | Cannon => return None,
+            | Cannon
+            | PolkadotTestnet => return None,
         };
 
         Some(api_key_name)


### PR DESCRIPTION
Adds Polkadot TestNet as it now offers an Ethereum compatibility layer. Chain ID is `420420417`.

Also modified Moonbeam/Moonriver average block times as it was improved from 12 seconds to 6 seconds.