### PR TITLE
chore: release 0.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.19](https://github.com/alloy-rs/chains/releases/tag/v0.2.19) - 2025-11-17
+## [0.2.20](https://github.com/alloy-rs/chains/releases/tag/v0.2.20) - 2025-11-19
+
+### Features
+
+- Add monad mainnet ([#227](https://github.com/alloy-rs/chains/issues/227))
+
+### Miscellaneous Tasks
+
+- Release 0.2.19 ([#226](https://github.com/alloy-rs/chains/issues/226))
 
 ### Other
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alloy-chains"
 description = "Canonical type definitions for EIP-155 chains"
-version = "0.2.19"
+version = "0.2.20"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Alloy Contributors"]


### PR DESCRIPTION
Pushed tag: https://github.com/alloy-rs/chains/releases/tag/v0.2.20

Released: https://crates.io/crates/alloy-chains/0.2.20