### PR TITLE
chore: release 0.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.23](https://github.com/alloy-rs/chains/releases/tag/v0.2.23) - 2025-12-09
+
+### Bug Fixes
+
+- T supports shanghai ([#235](https://github.com/alloy-rs/chains/issues/235))
+- T 500ms ([#234](https://github.com/alloy-rs/chains/issues/234))
+
 ## [0.2.22](https://github.com/alloy-rs/chains/releases/tag/v0.2.22) - 2025-12-08
 
 ### Features
@@ -14,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- Release 0.2.22
 - Release 0.2.21 ([#232](https://github.com/alloy-rs/chains/issues/232))
 - Release 0.2.20 ([#228](https://github.com/alloy-rs/chains/issues/228))
 - Release 0.2.19 ([#226](https://github.com/alloy-rs/chains/issues/226))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alloy-chains"
 description = "Canonical type definitions for EIP-155 chains"
-version = "0.2.22"
+version = "0.2.23"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Alloy Contributors"]


### PR DESCRIPTION
ref: https://crates.io/crates/alloy-chains/0.2.23 + https://github.com/alloy-rs/chains/releases/tag/v0.2.23