### PR TITLE
feat: add is_custom_sourcify for chains with Sourcify-compatible APIs

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -739,6 +739,16 @@ impl Chain {
         matches!(self.named(), Some(named) if named.is_tempo())
     }
 
+    /// Returns true if the chain uses a custom Sourcify-compatible API for contract verification.
+    ///
+    /// These chains have their verification URL registered in
+    /// [`etherscan_urls`](Self::etherscan_urls) but the API is Sourcify-compatible rather than
+    /// Etherscan-compatible.
+    #[inline]
+    pub const fn is_custom_sourcify(self) -> bool {
+        matches!(self.named(), Some(named) if named.is_custom_sourcify())
+    }
+
     /// Attempts to convert the chain into a named chain.
     #[inline]
     pub const fn named(self) -> Option<NamedChain> {

--- a/src/named.rs
+++ b/src/named.rs
@@ -781,6 +781,15 @@ impl NamedChain {
         matches!(self, Tempo | TempoModerato | TempoTestnet)
     }
 
+    /// Returns true if the chain uses a custom Sourcify-compatible API for contract verification.
+    ///
+    /// These chains have their verification URL registered in
+    /// [`etherscan_urls`](Self::etherscan_urls) but the API is Sourcify-compatible rather than
+    /// Etherscan-compatible.
+    pub const fn is_custom_sourcify(self) -> bool {
+        self.is_tempo()
+    }
+
     /// Returns the chain's average blocktime, if applicable.
     ///
     /// It can be beneficial to know the average blocktime to adjust the polling of an HTTP provider


### PR DESCRIPTION
## Summary

Some chains (like Tempo) register their contract verification URL in `etherscan_urls()` but the API is Sourcify-compatible rather than Etherscan-compatible. This helper allows consumers to detect such chains and use the appropriate verifier.

## Changes

Adds `is_custom_sourcify()` method to both `Chain` and `NamedChain`:

```rust
/// Returns true if the chain uses a custom Sourcify-compatible API for contract verification.
///
/// These chains have their verification URL registered in [`etherscan_urls`](Self::etherscan_urls)
/// but the API is Sourcify-compatible rather than Etherscan-compatible.
pub const fn is_custom_sourcify(self) -> bool {
    self.is_tempo()
}
```

## Use Case

In Foundry's `forge verify-contract`, this allows automatic detection of chains that need the Sourcify verifier with a custom URL from `etherscan_urls()` instead of the default Etherscan verifier.