### PR TITLE
fix: update Polkadot testnet explorer to use Routescan

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -2120,9 +2120,9 @@
       "supportsShanghai": true,
       "isTestnet": true,
       "nativeCurrencySymbol": "PAS",
-      "etherscanApiUrl": "https://blockscout-testnet.polkadot.io/api",
-      "etherscanBaseUrl": "https://blockscout-testnet.polkadot.io",
-      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
+      "etherscanApiUrl": "https://api.routescan.io/v2/network/testnet/evm/420420417/etherscan/api",
+      "etherscanBaseUrl": "https://polkadot.testnet.routescan.io",
+      "etherscanApiKeyName": "ROUTESCAN_API_KEY"
     },
     "420420418": {
       "internalId": "Kusama",

--- a/src/named.rs
+++ b/src/named.rs
@@ -1866,8 +1866,8 @@ impl NamedChain {
             TempoModerato => ("https://contracts.tempo.xyz", "https://explore.moderato.tempo.xyz"),
             TempoTestnet => ("https://contracts.tempo.xyz", "https://explore.andantino.tempo.xyz"),
             PolkadotTestnet => (
-                "https://blockscout-testnet.polkadot.io/api",
-                "https://blockscout-testnet.polkadot.io",
+                "https://api.routescan.io/v2/network/testnet/evm/420420417/etherscan/api",
+                "https://polkadot.testnet.routescan.io",
             ),
             Kusama => (
                 "https://blockscout-kusama.polkadot.io/api",
@@ -2023,7 +2023,6 @@ impl NamedChain {
             | SignetPecorino
             | SkaleBase
             | SkaleBaseSepoliaTestnet
-            | PolkadotTestnet
             | Kusama
             | Polkadot
             | ArcTestnet => "BLOCKSCOUT_API_KEY",
@@ -2036,7 +2035,7 @@ impl NamedChain {
             Zeta => "ZETASCAN_API_KEY",
             Kaia => "KAIASCAN_API_KEY",
             Berachain | BerachainBepolia => "BERASCAN_API_KEY",
-            Corn | CornTestnet => "ROUTESCAN_API_KEY",
+            Corn | CornTestnet | PolkadotTestnet => "ROUTESCAN_API_KEY",
             Plasma | PlasmaTestnet => "ETHERSCAN_API_KEY",
             // Explicitly exhaustive. See NB above.
             Metis


### PR DESCRIPTION
Change the explorer configuration from Blockscout to Routescan for the Polkadot testnet chain (420420417).
