### PR TITLE
fix: update zkSync explorer URLs to use native block explorer API

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -477,7 +477,7 @@
       "isTestnet": true,
       "nativeCurrencySymbol": "ETH",
       "etherscanApiUrl": "https://block-explorer-api.sepolia.zksync.dev/api",
-      "etherscanBaseUrl": "https://sepolia-era.zksync.network",
+      "etherscanBaseUrl": "https://sepolia.explorer.zksync.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "314": {
@@ -501,7 +501,7 @@
       "isTestnet": false,
       "nativeCurrencySymbol": "ETH",
       "etherscanApiUrl": "https://block-explorer-api.mainnet.zksync.io/api",
-      "etherscanBaseUrl": "https://era.zksync.network",
+      "etherscanBaseUrl": "https://explorer.zksync.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "338": {

--- a/src/named.rs
+++ b/src/named.rs
@@ -1660,11 +1660,11 @@ impl NamedChain {
             ),
             // ZkSync uses its own block explorer API (Etherscan v2 is deprecated/unavailable)
             ZkSync => {
-                ("https://block-explorer-api.mainnet.zksync.io/api", "https://era.zksync.network")
+                ("https://block-explorer-api.mainnet.zksync.io/api", "https://explorer.zksync.io")
             }
             ZkSyncTestnet => (
                 "https://block-explorer-api.sepolia.zksync.dev/api",
-                "https://sepolia-era.zksync.network",
+                "https://sepolia.explorer.zksync.io",
             ),
             Linea => ("https://api.etherscan.io/v2/api?chainid=59144", "https://lineascan.build"),
             LineaSepolia => {


### PR DESCRIPTION
Etherscan v2 API (api.etherscan.io/v2/api?chainid=...) is deprecated and unavailable for zkSync, returning 504 Gateway Timeout errors.

Updated to use zkSync's official block explorer APIs:
- Mainnet: https://block-explorer-api.mainnet.zksync.io/api
- Sepolia: https://block-explorer-api.sepolia.zksync.dev/api

Fixes: https://github.com/matter-labs/foundry-zksync/issues/1246