### PR TITLE
Update nativeCurrencySymbol of Stable Mainnet

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -691,7 +691,7 @@
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": false,
-      "nativeCurrencySymbol": "gUSDT",
+      "nativeCurrencySymbol": "USDT0",
       "etherscanApiUrl": "https://api.etherscan.io/v2/api?chainid=988",
       "etherscanBaseUrl": "https://stablescan.xyz",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"

--- a/src/named.rs
+++ b/src/named.rs
@@ -1443,8 +1443,7 @@ impl NamedChain {
             Kaia => "KAIA",
             Story => "IP",
             Sei | SeiTestnet => "SEI",
-            StableMainnet => "gUSDT",
-            StableTestnet => "USDT0",
+            StableMainnet | StableTestnet => "USDT0",
             ApeChain | Curtis => "APE",
 
             XdcMainnet => "XDC",


### PR DESCRIPTION
Stable v1.2.0 is live, and the native currency has been updated to USDT0 from gUSDT.

The official documentation is updated as well: https://docs.stable.xyz/en/developers/mainnet/mainnet-information