### PR TITLE
feat: add Radius Network and Radius Testnet

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -1712,8 +1712,8 @@
       "supportsShanghai": true,
       "isTestnet": true,
       "nativeCurrencySymbol": "RUSD",
-      "etherscanApiUrl": null,
-      "etherscanBaseUrl": null,
+      "etherscanApiUrl": "https://testnet.radiustech.xyz/api",
+      "etherscanBaseUrl": "https://testnet.radiustech.xyz",
       "etherscanApiKeyName": null
     },
     "80002": {
@@ -2012,8 +2012,8 @@
       "supportsShanghai": true,
       "isTestnet": false,
       "nativeCurrencySymbol": "RUSD",
-      "etherscanApiUrl": null,
-      "etherscanBaseUrl": null,
+      "etherscanApiUrl": "https://network.radiustech.xyz/api",
+      "etherscanBaseUrl": "https://network.radiustech.xyz",
       "etherscanApiKeyName": null
     },
     "747474": {

--- a/assets/chains.json
+++ b/assets/chains.json
@@ -1704,6 +1704,18 @@
       "etherscanBaseUrl": null,
       "etherscanApiKeyName": null
     },
+    "72344": {
+      "internalId": "RadiusTestnet",
+      "name": "radius-testnet",
+      "averageBlocktimeHint": 500,
+      "isLegacy": false,
+      "supportsShanghai": true,
+      "isTestnet": true,
+      "nativeCurrencySymbol": "RUSD",
+      "etherscanApiUrl": null,
+      "etherscanBaseUrl": null,
+      "etherscanApiKeyName": null
+    },
     "80002": {
       "internalId": "PolygonAmoy",
       "name": "amoy",
@@ -1991,6 +2003,18 @@
       "etherscanApiUrl": "https://api.etherscan.io/v2/api?chainid=660279",
       "etherscanBaseUrl": "https://xaiscan.io",
       "etherscanApiKeyName": "ETHERSCAN_API_KEY"
+    },
+    "723487": {
+      "internalId": "Radius",
+      "name": "radius",
+      "averageBlocktimeHint": 500,
+      "isLegacy": false,
+      "supportsShanghai": true,
+      "isTestnet": false,
+      "nativeCurrencySymbol": "RUSD",
+      "etherscanApiUrl": null,
+      "etherscanBaseUrl": null,
+      "etherscanApiKeyName": null
     },
     "747474": {
       "internalId": "Katana",

--- a/src/named.rs
+++ b/src/named.rs
@@ -1947,9 +1947,7 @@ impl NamedChain {
                 "https://explorer.testnet.chain.robinhood.com",
             ),
 
-            Radius => {
-                ("https://network.radiustech.xyz/api", "https://network.radiustech.xyz")
-            }
+            Radius => ("https://network.radiustech.xyz/api", "https://network.radiustech.xyz"),
             RadiusTestnet => {
                 ("https://testnet.radiustech.xyz/api", "https://testnet.radiustech.xyz")
             }
@@ -1958,8 +1956,8 @@ impl NamedChain {
             | AutonomysNovaTestnet | BaseGoerli | Canto | CantoTestnet | CronosTestnet | Dev
             | Evmos | EvmosTestnet | Fantom | FantomTestnet | FilecoinMainnet | Goerli | Iotex
             | KaruraTestnet | Koi | Kovan | LineaGoerli | MoonbeamDev | Morden | Oasis
-            | OptimismGoerli | OptimismKovan | Pgn | PgnSepolia | Poa
-            | Rinkeby | Ropsten | Sokol | Treasure | TreasureTopaz | Cannon => {
+            | OptimismGoerli | OptimismKovan | Pgn | PgnSepolia | Poa | Rinkeby | Ropsten
+            | Sokol | Treasure | TreasureTopaz | Cannon => {
                 return None;
             }
         })

--- a/src/named.rs
+++ b/src/named.rs
@@ -315,6 +315,13 @@ pub enum NamedChain {
     #[cfg_attr(feature = "serde", serde(alias = "ronin-testnet"))]
     RoninTestnet = 202601,
 
+    #[strum(to_string = "radius")]
+    #[cfg_attr(feature = "serde", serde(alias = "radius"))]
+    Radius = 723_487,
+    #[strum(to_string = "radius-testnet")]
+    #[cfg_attr(feature = "serde", serde(alias = "radius-testnet"))]
+    RadiusTestnet = 72_344,
+
     Taiko = 167000,
     #[cfg_attr(feature = "serde", serde(alias = "taiko-hekla"))]
     TaikoHekla = 167009,
@@ -967,6 +974,8 @@ impl NamedChain {
 
             ArcTestnet => 500,
 
+            Radius | RadiusTestnet => 500,
+
             Morden | Ropsten | Rinkeby | Goerli | Kovan | Sepolia | Holesky | Hoodi
             | MoonbeamDev | OptimismKovan | Poa | Sokol | EmeraldTestnet | Boba | Metis | Linea
             | LineaGoerli | LineaSepolia | Treasure | TreasureTopaz | Corn | CornTestnet
@@ -1120,7 +1129,9 @@ impl NamedChain {
             | Formicarium
             | Insectarium
             | MegaEth
-            | MegaEthTestnet => false,
+            | MegaEthTestnet
+            | Radius
+            | RadiusTestnet => false,
 
             // Unknown / not applicable, default to false for backwards compatibility.
             Dev
@@ -1303,6 +1314,8 @@ impl NamedChain {
                 | Sei
                 | Plume
                 | PlumeTestnet
+                | Radius
+                | RadiusTestnet
         )
     }
 
@@ -1400,6 +1413,7 @@ impl NamedChain {
             | PlasmaTestnet
             | ArcTestnet
             | BattleChainTestnet
+            | RadiusTestnet
             | RobinhoodTestnet => true,
 
             // Dev chains.
@@ -1417,7 +1431,7 @@ impl NamedChain {
             | Sonic | Superposition | Berachain | Monad | Unichain | TelosEvm | Story | Sei
             | Plume | StableMainnet | MegaEth | Hyperliquid | Abstract | Sophon | Lens | Corn
             | Katana | Lisk | Fuse | Injective | MemeCore | SkaleBase | XdcMainnet | Tempo
-            | Kusama | Polkadot => false,
+            | Kusama | Polkadot | Radius => false,
         }
     }
 
@@ -1532,6 +1546,8 @@ impl NamedChain {
             ArcTestnet => "USDC",
 
             Tempo | TempoModerato | TempoTestnet => "USD",
+
+            Radius | RadiusTestnet => "RUSD",
 
             _ => return None,
         })
@@ -1935,8 +1951,8 @@ impl NamedChain {
             | AutonomysNovaTestnet | BaseGoerli | Canto | CantoTestnet | CronosTestnet | Dev
             | Evmos | EvmosTestnet | Fantom | FantomTestnet | FilecoinMainnet | Goerli | Iotex
             | KaruraTestnet | Koi | Kovan | LineaGoerli | MoonbeamDev | Morden | Oasis
-            | OptimismGoerli | OptimismKovan | Pgn | PgnSepolia | Poa | Rinkeby | Ropsten
-            | Sokol | Treasure | TreasureTopaz | Cannon => {
+            | OptimismGoerli | OptimismKovan | Pgn | PgnSepolia | Poa | Radius | RadiusTestnet
+            | Rinkeby | Ropsten | Sokol | Treasure | TreasureTopaz | Cannon => {
                 return None;
             }
         })
@@ -2143,6 +2159,8 @@ impl NamedChain {
             | TempoTestnet
             | TempoModerato
             | Tempo
+            | Radius
+            | RadiusTestnet
             | BattleChainTestnet
             | RobinhoodTestnet => return None,
         };
@@ -2387,6 +2405,8 @@ mod tests {
             (MemeCore, &["memecore"]),
             (Formicarium, &["formicarium", "memecore-formicarium"]),
             (Insectarium, &["insectarium", "memecore-insectarium"]),
+            (Radius, &["radius"]),
+            (RadiusTestnet, &["radius-testnet"]),
             (RobinhoodTestnet, &["robinhood-testnet"]),
             (BattleChainTestnet, &["battlechain-testnet"]),
         ];

--- a/src/named.rs
+++ b/src/named.rs
@@ -1947,11 +1947,18 @@ impl NamedChain {
                 "https://explorer.testnet.chain.robinhood.com",
             ),
 
+            Radius => {
+                ("https://network.radiustech.xyz/api", "https://network.radiustech.xyz")
+            }
+            RadiusTestnet => {
+                ("https://testnet.radiustech.xyz/api", "https://testnet.radiustech.xyz")
+            }
+
             AcalaTestnet | AnvilHardhat | ArbitrumGoerli | ArbitrumTestnet
             | AutonomysNovaTestnet | BaseGoerli | Canto | CantoTestnet | CronosTestnet | Dev
             | Evmos | EvmosTestnet | Fantom | FantomTestnet | FilecoinMainnet | Goerli | Iotex
             | KaruraTestnet | Koi | Kovan | LineaGoerli | MoonbeamDev | Morden | Oasis
-            | OptimismGoerli | OptimismKovan | Pgn | PgnSepolia | Poa | Radius | RadiusTestnet
+            | OptimismGoerli | OptimismKovan | Pgn | PgnSepolia | Poa
             | Rinkeby | Ropsten | Sokol | Treasure | TreasureTopaz | Cannon => {
                 return None;
             }


### PR DESCRIPTION
Add Radius (723487) and Radius Testnet (72344) chain definitions.

Radius is an EVM-compatible stablecoin platform with sub-second finality and stablecoin-native fees (~$0.0001/tx).

## Chain details

| | Mainnet | Testnet |
|---|---|---|
| Chain ID | 723487 | 72344 |
| RPC | https://rpc.radiustech.xyz | https://rpc.testnet.radiustech.xyz |
| Explorer | https://network.radiustech.xyz | https://testnet.radiustech.xyz |
| Native currency | RUSD (18 decimals) | RUSD (18 decimals) |

- EIP-1559 and legacy transactions supported
- Shanghai supported

Website: https://radiustech.xyz
Docs: https://docs.radiustech.xyz
ethereum-lists/chains: https://github.com/ethereum-lists/chains/pull/8168 (merged)