### PR TITLE
feat: add Redbelly Network (151) and testnet (153)

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -396,6 +396,30 @@
       "etherscanBaseUrl": "https://explorer.evm.shimmer.network",
       "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
     },
+    "151": {
+      "internalId": "Redbelly",
+      "name": "redbelly",
+      "averageBlocktimeHint": 60000,
+      "isLegacy": false,
+      "supportsShanghai": true,
+      "isTestnet": false,
+      "nativeCurrencySymbol": "RBNT",
+      "etherscanApiUrl": "https://api.routescan.io/v2/network/mainnet/evm/151/etherscan",
+      "etherscanBaseUrl": "https://redbelly.routescan.io",
+      "etherscanApiKeyName": "ROUTESCAN_API_KEY"
+    },
+    "153": {
+      "internalId": "RedbellyTestnet",
+      "name": "redbelly-testnet",
+      "averageBlocktimeHint": 60000,
+      "isLegacy": false,
+      "supportsShanghai": true,
+      "isTestnet": true,
+      "nativeCurrencySymbol": "RBNT",
+      "etherscanApiUrl": "https://api.routescan.io/v2/network/testnet/evm/153/etherscan",
+      "etherscanBaseUrl": "https://redbelly.testnet.routescan.io",
+      "etherscanApiKeyName": "ROUTESCAN_API_KEY"
+    },
     "204": {
       "internalId": "OpBNBMainnet",
       "name": "opbnb-mainnet",

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -595,6 +595,18 @@ impl Chain {
         Self::from_named(NamedChain::SonicTestnet)
     }
 
+    /// Returns the Redbelly Network mainnet chain.
+    #[inline]
+    pub const fn redbelly() -> Self {
+        Self::from_named(NamedChain::Redbelly)
+    }
+
+    /// Returns the Redbelly Network testnet chain.
+    #[inline]
+    pub const fn redbelly_testnet() -> Self {
+        Self::from_named(NamedChain::RedbellyTestnet)
+    }
+
     /// Returns the Superposition testnet chain.
     #[inline]
     pub const fn superposition_testnet() -> Self {

--- a/src/named.rs
+++ b/src/named.rs
@@ -439,6 +439,13 @@ pub enum NamedChain {
     #[cfg_attr(feature = "serde", serde(alias = "sonic-testnet"))]
     SonicTestnet = 14601,
 
+    #[strum(to_string = "redbelly")]
+    #[cfg_attr(feature = "serde", serde(alias = "redbelly"))]
+    Redbelly = 151,
+    #[strum(to_string = "redbelly-testnet")]
+    #[cfg_attr(feature = "serde", serde(alias = "redbelly-testnet"))]
+    RedbellyTestnet = 153,
+
     #[strum(to_string = "plume-testnet")]
     #[cfg_attr(feature = "serde", serde(alias = "plume-testnet"))]
     PlumeTestnet = 98867,
@@ -947,6 +954,8 @@ impl NamedChain {
 
             Sonic | SonicTestnet => 1_000,
 
+            Redbelly | RedbellyTestnet => 60_000,
+
             TelosEvm | TelosEvmTestnet | Tempo | TempoTestnet | TempoModerato | TempoDevnet => 500,
 
             UnichainSepolia | Unichain => 1_000,
@@ -1094,6 +1103,8 @@ impl NamedChain {
             | SoneiumMinatoTestnet
             | Sonic
             | SonicTestnet
+            | Redbelly
+            | RedbellyTestnet
             | World
             | WorldSepolia
             | Unichain
@@ -1315,6 +1326,8 @@ impl NamedChain {
                 | ArcTestnet
                 | BattleChainTestnet
                 | Sonic
+                | Redbelly
+                | RedbellyTestnet
                 | Katana
                 | Linea
                 | Sei
@@ -1394,6 +1407,7 @@ impl NamedChain {
             | PlumeTestnet
             | TreasureTopaz
             | SonicTestnet
+            | RedbellyTestnet
             | BerachainBepolia
             | SuperpositionTestnet
             | MonadTestnet
@@ -1435,10 +1449,10 @@ impl NamedChain {
             | Elastos | Degen | OpBNBMainnet | Ronin | Taiko | Flare | Acala | Karura
             | Darwinia | Cfx | Crab | Pulsechain | Etherlink | Immutable | World | Iotex | Core
             | Merlin | Bitlayer | ApeChain | Vana | Zeta | Kaia | Treasure | Bob | Soneium
-            | Sonic | Superposition | Berachain | Monad | Unichain | TelosEvm | Story | Sei
-            | Plume | StableMainnet | MegaEth | Hyperliquid | Abstract | Sophon | Lens | Corn
-            | Katana | Lisk | Fuse | Injective | MemeCore | SkaleBase | XdcMainnet | Tempo
-            | Kusama | Polkadot | Radius => false,
+            | Sonic | Redbelly | Superposition | Berachain | Monad | Unichain | TelosEvm
+            | Story | Sei | Plume | StableMainnet | MegaEth | Hyperliquid | Abstract | Sophon
+            | Lens | Corn | Katana | Lisk | Fuse | Injective | MemeCore | SkaleBase
+            | XdcMainnet | Tempo | Kusama | Polkadot | Radius => false,
         }
     }
 
@@ -1516,6 +1530,8 @@ impl NamedChain {
             Monad | MonadTestnet => "MON",
 
             Sonic | SonicTestnet => "S",
+
+            Redbelly | RedbellyTestnet => "RBNT",
 
             TelosEvm | TelosEvmTestnet => "TLOS",
 
@@ -1850,6 +1866,14 @@ impl NamedChain {
             SonicTestnet => {
                 ("https://api.etherscan.io/v2/api?chainid=14601", "https://testnet.sonicscan.org")
             }
+            Redbelly => (
+                "https://api.routescan.io/v2/network/mainnet/evm/151/etherscan",
+                "https://redbelly.routescan.io",
+            ),
+            RedbellyTestnet => (
+                "https://api.routescan.io/v2/network/testnet/evm/153/etherscan",
+                "https://redbelly.testnet.routescan.io",
+            ),
             BerachainBepolia => {
                 ("https://api.etherscan.io/v2/api?chainid=80069", "https://testnet.berascan.com")
             }
@@ -2121,6 +2145,7 @@ impl NamedChain {
             Kaia => "KAIASCAN_API_KEY",
             Berachain | BerachainBepolia => "BERASCAN_API_KEY",
             Corn | CornTestnet => "ROUTESCAN_API_KEY",
+            Redbelly | RedbellyTestnet => "ROUTESCAN_API_KEY",
             Plasma | PlasmaTestnet => "ETHERSCAN_API_KEY",
             // Explicitly exhaustive. See NB above.
             Metis
@@ -2270,6 +2295,7 @@ impl NamedChain {
             Treasure => address!("263d8f36bb8d0d9526255e205868c26690b04b88"),
             Superposition => address!("1fB719f10b56d7a85DCD32f27f897375fB21cfdd"),
             Sonic => address!("039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38"),
+            Redbelly => address!("6ed1f491e2d31536d6561f6bdb2adc8f092a6076"),
             Berachain => address!("6969696969696969696969696969696969696969"),
             Hyperliquid => address!("5555555555555555555555555555555555555555"),
             Abstract => address!("3439153EB7AF838Ad19d56E1571FBD09333C2809"),
@@ -2422,6 +2448,8 @@ mod tests {
             (RadiusTestnet, &["radius-testnet"]),
             (RobinhoodTestnet, &["robinhood-testnet"]),
             (BattleChainTestnet, &["battlechain-testnet"]),
+            (Redbelly, &["redbelly"]),
+            (RedbellyTestnet, &["redbelly-testnet"]),
         ];
 
         for &(chain, aliases) in ALIASES {


### PR DESCRIPTION
## Summary

Adds Redbelly Network mainnet (chain ID `151`) and testnet (chain ID `153`) to the `NamedChain` registry.

Currently blocks Foundry users from running `forge script` / `forge create` on Redbelly without `--legacy` workarounds, since Foundry depends on this crate to identify chains.

## Chain details

| Field | Mainnet | Testnet |
|---|---|---|
| Chain ID | 151 | 153 |
| Name | Redbelly Network Mainnet | Redbelly Network Testnet |
| Native currency | RBNT (18 decimals) | RBNT (18 decimals) |
| RPC | https://governors.mainnet.redbelly.network | https://governors.testnet.redbelly.network |
| Explorer | https://redbelly.routescan.io | https://redbelly.testnet.routescan.io |
| Explorer API (Routescan) | https://api.routescan.io/v2/network/mainnet/evm/151/etherscan | https://api.routescan.io/v2/network/testnet/evm/153/etherscan |
| EIP-1559 | Yes (verified via `eth_getBlockByNumber` → `baseFeePerGas`) | Yes (verified) |
| Shanghai / PUSH0 | Yes (Redbelly EVM is on Prague) | Yes |
| Avg block time | ~60s | ~60s |
| Wrapped native (WRBNT) | `0x6ed1f491e2d31536d6561f6bdb2adc8f092a6076` | — |

## Changes

- `src/named.rs` — adds `Redbelly` / `RedbellyTestnet` variants and wires them into `average_blocktime_hint`, `is_legacy` (non-legacy list), `supports_shanghai`, `is_testnet`, `native_currency_symbol`, `etherscan_urls` (Routescan), `etherscan_api_key_name` (shared `ROUTESCAN_API_KEY` with Corn), `wrapped_native_token` (mainnet only), and the alias test.
- `src/chain.rs` — adds `Chain::redbelly()` and `Chain::redbelly_testnet()` convenience constructors (matches pattern in #272).
- `assets/chains.json` — auto-regenerated by `spec::tests::spec_up_to_date`.

## Sources

- ethereum-lists/chains: [`eip155-151.json`](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-151.json), [`eip155-153.json`](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-153.json)
- Redbelly official environments: https://vine.redbelly.network/environments
- Redbelly EVM (Prague): https://vine.redbelly.network/evm
- Block time: https://chainspect.app/chain/redbelly
- EIP-1559 support: confirmed live via `eth_getBlockByNumber` against both RPCs (non-null `baseFeePerGas`)

## Checklist

- [x] \`cargo test --all-features\` passes (21 unit + 6 doctests)
- [x] \`cargo +nightly fmt --all\` applied
- [x] \`cargo clippy --all-features\` clean
- [x] \`assets/chains.json\` regenerated by the test suite (no manual edits)

Prompted by: need for Foundry support on Redbelly Network mainnet deployments.