### PR TITLE
feat(fluent): add fluent mainnet, fix incorrect explorer links for fluent devnet and testnet

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -1376,8 +1376,8 @@
       "supportsShanghai": true,
       "isTestnet": true,
       "nativeCurrencySymbol": null,
-      "etherscanApiUrl": "https://blockscout.dev.gblend.xyz/api",
-      "etherscanBaseUrl": "https://blockscout.dev.gblend.xyz",
+      "etherscanApiUrl": "https://api-devnet.fluentscan.xyz/api",
+      "etherscanBaseUrl": "https://devnet.fluentscan.xyz",
       "etherscanApiKeyName": null
     },
     "20994": {
@@ -1388,8 +1388,20 @@
       "supportsShanghai": true,
       "isTestnet": true,
       "nativeCurrencySymbol": null,
-      "etherscanApiUrl": "https://testnet.fluentscan.xyz/api",
+      "etherscanApiUrl": "https://api-testnet.fluentscan.xyz/api",
       "etherscanBaseUrl": "https://testnet.fluentscan.xyz",
+      "etherscanApiKeyName": null
+    },
+    "25363": {
+      "internalId": "Fluent",
+      "name": "fluent",
+      "averageBlocktimeHint": 1000,
+      "isLegacy": false,
+      "supportsShanghai": false,
+      "isTestnet": false,
+      "nativeCurrencySymbol": null,
+      "etherscanApiUrl": "https://api.fluentscan.xyz/api",
+      "etherscanBaseUrl": "https://fluentscan.xyz",
       "etherscanApiKeyName": null
     },
     "26863": {

--- a/src/named.rs
+++ b/src/named.rs
@@ -559,10 +559,14 @@ pub enum NamedChain {
     #[strum(to_string = "fuse")]
     #[cfg_attr(feature = "serde", serde(alias = "fuse"))]
     Fuse = 122,
+
+    #[strum(to_string = "fluent")]
+    #[cfg_attr(feature = "serde", serde(alias = "fluent"))]
+    Fluent = 25363,
+
     #[strum(to_string = "fluent-devnet")]
     #[cfg_attr(feature = "serde", serde(alias = "fluent-devnet"))]
     FluentDevnet = 20993,
-
     #[strum(to_string = "fluent-testnet")]
     #[cfg_attr(feature = "serde", serde(alias = "fluent-testnet"))]
     FluentTestnet = 20994,
@@ -981,6 +985,7 @@ impl NamedChain {
             Katana => 1_000,
             Lisk => 2_000,
             Fuse => 5_000,
+            Fluent => 1_000,
             FluentDevnet => 3_000,
             FluentTestnet => 1_000,
             MemeCore | Formicarium | Insectarium => 7_000,
@@ -1142,6 +1147,7 @@ impl NamedChain {
             | KaruraTestnet
             | TelosEvm
             | TelosEvmTestnet
+            | Fluent
             | FluentDevnet
             | FluentTestnet
             | Plasma
@@ -1459,7 +1465,7 @@ impl NamedChain {
             | Sonic | Redbelly | Superposition | Berachain | Monad | Unichain | TelosEvm
             | Story | Sei | Plume | StableMainnet | MegaEth | Hyperliquid | Abstract | Sophon
             | Lens | Corn | Katana | Lisk | Fuse | Injective | MemeCore | SkaleBase
-            | XdcMainnet | Tempo | Kusama | Polkadot | Radius => false,
+            | XdcMainnet | Tempo | Kusama | Polkadot | Radius | Fluent => false,
         }
     }
 
@@ -1943,12 +1949,9 @@ impl NamedChain {
                 "https://testnet.blockscout-api.injective.network/api",
                 "https://testnet.blockscout.injective.network",
             ),
-            FluentDevnet => {
-                ("https://blockscout.dev.gblend.xyz/api", "https://blockscout.dev.gblend.xyz")
-            }
-            FluentTestnet => {
-                ("https://testnet.fluentscan.xyz/api", "https://testnet.fluentscan.xyz")
-            }
+            Fluent => ("https://api.fluentscan.xyz/api", "https://fluentscan.xyz"),
+            FluentDevnet => ("https://api-devnet.fluentscan.xyz/api", "https://devnet.fluentscan.xyz"),
+            FluentTestnet => ("https://api-testnet.fluentscan.xyz/api", "https://testnet.fluentscan.xyz"),
             MemeCore => ("https://api.etherscan.io/v2/api?chainid=4352", "https://memecorescan.io"),
             Formicarium => (
                 "https://api.etherscan.io/v2/api?chainid=43521",
@@ -2200,6 +2203,7 @@ impl NamedChain {
             | TelosEvmTestnet
             | Lens
             | LensTestnet
+            | Fluent
             | FluentDevnet
             | FluentTestnet
             | Cannon

--- a/src/named.rs
+++ b/src/named.rs
@@ -1950,8 +1950,12 @@ impl NamedChain {
                 "https://testnet.blockscout.injective.network",
             ),
             Fluent => ("https://api.fluentscan.xyz/api", "https://fluentscan.xyz"),
-            FluentDevnet => ("https://api-devnet.fluentscan.xyz/api", "https://devnet.fluentscan.xyz"),
-            FluentTestnet => ("https://api-testnet.fluentscan.xyz/api", "https://testnet.fluentscan.xyz"),
+            FluentDevnet => {
+                ("https://api-devnet.fluentscan.xyz/api", "https://devnet.fluentscan.xyz")
+            }
+            FluentTestnet => {
+                ("https://api-testnet.fluentscan.xyz/api", "https://testnet.fluentscan.xyz")
+            }
             MemeCore => ("https://api.etherscan.io/v2/api?chainid=4352", "https://memecorescan.io"),
             Formicarium => (
                 "https://api.etherscan.io/v2/api?chainid=43521",


### PR DESCRIPTION
Supersedes #271 because the original contributor branch could not be updated from the maintainer side.

This replacement PR:
- adds `NamedChain::Fluent` with chain ID `25363`
- updates the Fluent devnet/testnet explorer endpoints
- regenerates `assets/chains.json`
- applies the current `rustfmt` formatting expected by the repository

Validation:
- `cargo test --all-features`
- `cargo +nightly fmt --all --check`
