### PR TITLE
Update BSC block interval

### DIFF
--- a/src/named.rs
+++ b/src/named.rs
@@ -893,7 +893,7 @@ impl NamedChain {
 
             Moonbeam | Moonriver | Moonbase => 6_500,
 
-            BinanceSmartChain | BinanceSmartChainTestnet => 750,
+            BinanceSmartChain | BinanceSmartChainTestnet => 450,
 
             Avalanche | AvalancheFuji => 2_000,
 


### PR DESCRIPTION
[BEP-619](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP-619.md) sets BSC block interval to 450ms.

It's included in BSC Fermi hard fork that already activated both on BSC-Mainnet and BSC-Testnet:
Testnet: 2025-11-10 02:25:00 AM UTC
Mainnet: 2026-01-14 02:30:00 AM UTC
(Can be found in [BSC HardFork Roadmap](https://forum.bnbchain.org/t/bnb-chain-roadmap-mainnet/936))
