### PR TITLE
fix: update BSC blocktime spec asset

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -219,7 +219,7 @@
     "56": {
       "internalId": "BinanceSmartChain",
       "name": "bsc",
-      "averageBlocktimeHint": 750,
+      "averageBlocktimeHint": 450,
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": false,
@@ -279,7 +279,7 @@
     "97": {
       "internalId": "BinanceSmartChainTestnet",
       "name": "bsc-testnet",
-      "averageBlocktimeHint": 750,
+      "averageBlocktimeHint": 450,
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": true,


### PR DESCRIPTION
## Summary
- Update the generated chain spec asset for BSC and BSC Testnet to 450ms.
- Keep `assets/chains.json` in sync with `NamedChain::average_blocktime_hint` after #288.

## Root Cause
#288 changed the Rust blocktime hints, but the generated JSON snapshot still had 750ms. The all-features spec freshness test rewrites that file and fails CI when it is stale.