### PR TITLE
docs: correct etherscan url examples in Chain spec

### DIFF
--- a/assets/chains.schema.json
+++ b/assets/chains.schema.json
@@ -40,14 +40,14 @@
           ]
         },
         "etherscanApiUrl": {
-          "description": "The chain's base block explorer API URL (e.g. `https://api.etherscan.io/`).",
+          "description": "The chain's base block explorer API URL (e.g. `https://api.etherscan.io/v2/api?chainid=1`).",
           "type": [
             "string",
             "null"
           ]
         },
         "etherscanBaseUrl": {
-          "description": "The chain's base block explorer base URL (e.g. `https://etherscan.io/`).",
+          "description": "The chain's base block explorer base URL (e.g. `https://etherscan.io`).",
           "type": [
             "string",
             "null"

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -58,9 +58,9 @@ pub struct Chain {
     pub is_testnet: bool,
     /// The chain's native currency symbol (e.g. `ETH`).
     pub native_currency_symbol: Option<String>,
-    /// The chain's base block explorer API URL (e.g. `https://api.etherscan.io/`).
+    /// The chain's base block explorer API URL (e.g. `https://api.etherscan.io/v2/api?chainid=1`).
     pub etherscan_api_url: Option<String>,
-    /// The chain's base block explorer base URL (e.g. `https://etherscan.io/`).
+    /// The chain's base block explorer base URL (e.g. `https://etherscan.io`).
     pub etherscan_base_url: Option<String>,
     /// The name of the environment variable that contains the Etherscan API key.
     pub etherscan_api_key_name: Option<String>,


### PR DESCRIPTION
## Summary
- The doc examples for `etherscan_api_url` and `etherscan_base_url` on `Chain` had trailing slashes, which contradicts the `ensure_no_trailing_etherscan_url_separator` test invariant that asserts no etherscan url ends with `/`.
- The api url example was also the pre-V2 form. Updated both to the current mainnet values: `https://api.etherscan.io/v2/api?chainid=1` and `https://etherscan.io`.
- Regenerated `assets/chains.schema.json`, which embeds these doc comments as field descriptions.

## Tests
- `cargo test --no-default-features --features std,schema,serde` (schema_up_to_date, spec_up_to_date, ensure_no_trailing_etherscan_url_separator pass)
- `cargo +nightly fmt --all --check`
- `cargo clippy --workspace --all-features`