### PR TITLE
fix: ignore unaffected ruint advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,11 @@ yanked = "warn"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
     "RUSTSEC-2024-0436",
+    # ruint's affected Uint operations are not used; alloy-chains only uses
+    # alloy-primitives' Address type. The fixed ruint release requires Rust 1.90,
+    # while alloy-chains supports Rust 1.85.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0220
+    "RUSTSEC-2026-0220",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

- add a documented exception for `RUSTSEC-2026-0220`
- preserve the crate's Rust 1.85 MSRV while restoring the `cargo deny` gate

## Rationale

The advisory affects `ruint`'s `Uint` shift operations and related no-alloc formatting behavior. `alloy-chains` only consumes `alloy-primitives::Address`, so it does not use the affected API surface.

Cargo resolves `ruint 1.17.2` for this crate because the fixed `ruint 1.20.0` release requires Rust 1.90. Raising the MSRV would be disproportionate for an unaffected transitive dependency; the narrowly scoped exception keeps that constraint explicit until the dependency can be upgraded.
